### PR TITLE
publish pypi quickfix

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -72,7 +72,8 @@ jobs:
         architecture: ${{ matrix.python_arch }}
     - name: install dependencies
       run: |
-        python -mpip install --progress-bar=off cibuildwheel -r ci/requirements.txt
+        python -m pip install --progress-bar=off cibuildwheel -r ci/requirements.txt
+        python -m pip install git+https://github.com/InstituteforDiseaseModeling/RasterToolkit.git
         virtualenv --version
         pip --version
         tox --version
@@ -114,11 +115,11 @@ jobs:
       if: matrix.cibw_build
       with:
         path: wheelhouse/*.whl
-  finish:
-    needs: test
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    steps:
-    - uses: codecov/codecov-action@v3
-      with:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  # finish:
+  #   needs: test
+  #   if: ${{ always() }}
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: codecov/codecov-action@v3
+  #     with:
+  #       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI and TestPyPi
+name: Publish to PyPI
 
 on:
   workflow_run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ name = "laser-measles"
 version = "0.6.0"
 
 dependencies = [
-  "laser-core @ git+https://github.com/InstituteforDiseaseModeling/laser.git@v0.5.1",
-  "rastertoolkit @ git+https://github.com/InstituteforDiseaseModeling/RasterToolkit.git",
+  "laser-core==0.5.1",
   "diskcache>=5.6.3",
   "appdirs>=1.4.4",
   "pydantic>=2.11.5",


### PR DESCRIPTION
This pull request includes updates to the project's dependencies and workflows, focusing on simplifying configurations and improving dependency management. Key changes include modifying how dependencies are installed, updating workflow steps, and refining dependency specifications in `pyproject.toml`.

### Workflow updates:

* [`.github/workflows/github-actions.yml`](diffhunk://#diff-d8485ae5feb85d5310fbb669eca158cacafdba09b695a16d47720b69b9072e23R76): Added installation of `RasterToolkit` directly from its repository during the dependency installation step.
* [`.github/workflows/github-actions.yml`](diffhunk://#diff-d8485ae5feb85d5310fbb669eca158cacafdba09b695a16d47720b69b9072e23L117-R125): Commented out the `finish` job, which included Codecov integration, effectively disabling it for now.
* [`.github/workflows/publish-pypi.yml`](diffhunk://#diff-d4585bdbbb00b46a400628c271f195eb312333d18474299152a0b75fb1a7ec4bL1-R1): Updated the workflow name to "Publish to PyPI," removing references to TestPyPi.

### Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L10-R10): Changed the specification of `laser-core` from a Git-based URL to a version-based dependency (`laser-core==0.5.1`) and removed the `RasterToolkit` dependency.