### PR TITLE
Cibuildwheel

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,22 +11,24 @@ jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.12"]
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install pypa/build
-      run: >-
-        python3 -m 
-        pip install build --user
-    - name: Build a binary wheel and a source tarball
-      run: python3 -m build --manylinux 2014
+        python-version: "3.12"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build
+    - name: Build source distribution
+      run: python -m build --sdist
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.16.2
+      env:
+        CIBW_BUILD: cp312-*
+        CIBW_ARCHS_LINUX: x86_64
     - name: Store the distribution packages
       uses: actions/upload-artifact@v4
       with:
@@ -94,5 +96,3 @@ jobs:
       run: |
         tag_name=v$(bump-my-version show current_version)
         gh release upload "$tag_name" dist/*
-
-  

--- a/src/laser_measles/demographics/shapefiles.py
+++ b/src/laser_measles/demographics/shapefiles.py
@@ -81,8 +81,11 @@ def add_dotname(
     if inplace:
         for suffix in [".shp", ".shx", ".prj", ".cpg", ".prj", ".dbf"]:
             temp_path = make_temp_path(path, append_suffix=append_suffix, suffix=suffix)
+            target_path = path.with_suffix(suffix)
             if temp_path.exists():
-                temp_path.rename(path.with_suffix(suffix))
+                if target_path.exists():
+                    target_path.unlink()  # Remove existing file first
+                temp_path.rename(target_path)
 
 
 def get_dataframe(shapefile_path: str | Path) -> pl.DataFrame:


### PR DESCRIPTION
This pull request introduces changes to streamline the Python packaging workflow and improve file handling in the `shapefiles.py` module. The most important changes include updates to the `.github/workflows/publish-pypi.yml` file to enhance the build process and modifications to the `make_temp_path` function to handle existing files more robustly.

### Workflow improvements for Python packaging:

* [`.github/workflows/publish-pypi.yml`](diffhunk://#diff-d4585bdbbb00b46a400628c271f195eb312333d18474299152a0b75fb1a7ec4bL14-R31): Simplified the Python version setup by removing the matrix strategy and directly specifying Python 3.12. Updated the build steps to use `cibuildwheel` for wheel creation and added explicit commands for upgrading `pip` and installing dependencies. This improves compatibility and streamlines the packaging process.
* [`.github/workflows/publish-pypi.yml`](diffhunk://#diff-d4585bdbbb00b46a400628c271f195eb312333d18474299152a0b75fb1a7ec4bL97-L98): Removed unnecessary blank lines in the release upload step for better readability.

### File handling improvements:

* [`src/laser_measles/demographics/shapefiles.py`](diffhunk://#diff-23f5e3fc8cfd57d5c141b437f4fac53290810a76b027fdd71864bd04a9f625faR84-R88): Enhanced the `make_temp_path` function to check if the target file already exists before renaming a temporary file. If the target file exists, it is now removed first to prevent conflicts.