### PR TITLE
remove sidebar, add server for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
               "ms-toolsai.jupyter-renderers",
               "charliermarsh.ruff",
               "github.codespace",
-              "vscode-icons-team.vscode-icons"
+              "vscode-icons-team.vscode-icons",
+              "ms-vscode.live-server"
           ]
       }
   },

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ html_theme_options = {
         },
     ],
     "navbar_end": ["theme-switcher", "navbar-icon-links"],
-    "secondary_sidebar_items": ["navbar-side"],
+    "secondary_sidebar_items": [],
     "header_links_before_dropdown": 5,
     "footer_start": ["copyright", "footer_start"],
     "footer_end": ["theme-version", "footer_end"],

--- a/docs/reference/laser_measles.rst
+++ b/docs/reference/laser_measles.rst
@@ -38,26 +38,10 @@ laser\_measles.base module
    :show-inheritance:
    :undoc-members:
 
-laser\_measles.cli module
--------------------------
-
-.. automodule:: laser_measles.cli
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
 laser\_measles.core module
 --------------------------
 
 .. automodule:: laser_measles.core
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-laser\_measles.protocols module
--------------------------------
-
-.. automodule:: laser_measles.protocols
    :members:
    :show-inheritance:
    :undoc-members:


### PR DESCRIPTION
This pull request includes updates to the development container configuration and documentation files. The most significant changes involve adding a new extension to the devcontainer setup and streamlining the documentation structure.

### Development Environment Updates:
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L14-R15): Added the `ms-vscode.live-server` extension to the devcontainer configuration to enhance live preview capabilities.

### Documentation Structure Simplification:
* [`docs/conf.py`](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3L80-R80): Removed `navbar-side` from `secondary_sidebar_items` to simplify the sidebar configuration.
* [`docs/reference/laser_measles.rst`](diffhunk://#diff-d180b62820c4714b63b24054768fa2359a889cf1f6aef2fc25bd1060abe69812L41-L48): Removed documentation sections for `laser_measles.cli` and `laser_measles.protocols` modules to streamline the reference structure. [[1]](diffhunk://#diff-d180b62820c4714b63b24054768fa2359a889cf1f6aef2fc25bd1060abe69812L41-L48) [[2]](diffhunk://#diff-d180b62820c4714b63b24054768fa2359a889cf1f6aef2fc25bd1060abe69812L57-L64)