### PR TITLE
fix: Replace cibuildwheel with python -m build for pure Python package

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -22,17 +22,17 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install build
-    - name: Build source distribution
-      run: python -m build --sdist
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v2.16.2
-      env:
-        CIBW_BUILD: cp312-*
-        CIBW_ARCHS_LINUX: x86_64
-    - name: Move wheels to dist directory
-      run: |
-        mkdir -p dist
-        cp wheelhouse/*.whl dist/
+    - name: Build sdist and wheel
+      run: python -m build
+    # - name: Build platform wheels
+    #   uses: pypa/cibuildwheel@v2.16.2
+    #   env:
+    #     CIBW_BUILD: cp312-*
+    #     CIBW_ARCHS_LINUX: x86_64
+    # - name: Move wheels to dist directory
+    #   run: |
+    #     mkdir -p dist
+    #     cp wheelhouse/*.whl dist/
     - name: Store the distribution packages
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
The uv_build backend produces pure Python wheels (py3-none-any.whl), which cibuildwheel rejects with NonPlatformWheelError. Use python -m build instead. cibuildwheel config is commented out for future use when C/Rust extensions are added.