### PR TITLE
pin rastertools version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "sciris>=3.2.1",
   "polars>=1.30.0",
   "pyarrow>=20.0.0",
-  "rastertoolkit==0.3.12",
+  "rastertoolkit==0.3.12",  # Pinned to 0.3.12 until rastertoolkit resolves pyshp 3.0 compatibility (see #121)
   "typer>=0.12.0",
   "patito>=0.8.3",
   "pyvd>=1.0.1",


### PR DESCRIPTION
Pin rastertools to before upgrade to pyshop 3.0.  Will follow up with Rastertoolkit about this issue.
Closes #121 