### PR TITLE
We think the current rtd build error is a result of the jupyter conve…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,7 @@ nbsphinx_execute = "auto"
 nbsphinx_timeout = 600
 nbsphinx_allow_errors = True
 nbsphinx_execute_arguments = [
-    "--InlineBackend.figure_formats={'svg', 'pdf'}",
+    "--InlineBackend.figure_formats={'png'}",
     "--InlineBackend.rc={'figure.dpi': 96}",
 ]
 


### PR DESCRIPTION
…rsion (unnecessarily) creating pdf files and then the pdf build getting angry about these pdf files being there. These jp pdfs are actually imagery so can be pngs instead.