### PR TITLE
deps: combine all dependabot requirement updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,17 +38,17 @@ classifiers = [
 ]
 
 dependencies = [
-  "laser-core>=1.0.0",
+  "laser-core>=1.0.1",
   "diskcache>=5.0",
-  "appdirs>=1.4",
-  "pydantic>=2.0",
-  "pycountry>=22.3",
+  "appdirs>=1.4.4",
+  "pydantic>=2.12.5",
+  "pycountry>=26.2.16",
   "requests>=2.28",
   "alive-progress>=3.0",
-  "polars>=1.0.0",
+  "polars>=1.39.3",
   "rastertoolkit>=0.3.11",
   "typer>=0.9",
-  "patito>=0.8",
+  "patito>=0.8.6",
   "pyvd>=1.0",
 ]
 
@@ -149,7 +149,7 @@ replace = '__version__ = "{new_version}"'
 dev = [
     "ruff",
     "pytest",
-    "pytest-order>=1.1.1",
+    "pytest-order>=1.3.0",
     "pyright",
     "mypy",
     "bump-my-version"
@@ -171,16 +171,16 @@ docs = [
 ]
 examples = [
     "jupytext>=1.17.2",
-    "notebook>=7.4.3",
+    "notebook>=7.5.5",
     "seaborn>=0.13.2",
     "ipykernel>=7.2.0",
-    "optuna>=4.4.0",
+    "optuna>=4.8.0",
     "plotly>=6.2.0",
 ]
 full = [
     "ruff",
     "pytest",
-    "pytest-order>=1.1.1",
+    "pytest-order>=1.3.0",
     "pyright",
     "mypy",
     "bump-my-version",
@@ -198,9 +198,9 @@ full = [
     "mkdocs-table-reader-plugin",
     "mkdocs-exclude",
     "jupytext>=1.17.2",
-    "notebook>=7.4.3",
+    "notebook>=7.5.5",
     "seaborn>=0.13.2",
     "ipykernel>=7.2.0",
-    "optuna>=4.4.0",
+    "optuna>=4.8.0",
     "plotly>=6.2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "laser.measles"
-version = "0.10.0"
+version = "0.10.1"
 authors = [
   {name = "Christopher Lorton"},
   {name = "Jonathan Bloedow"},
@@ -119,7 +119,7 @@ force-single-line = true
 quote-style = "double"
 
 [tool.bumpversion]
-current_version = "0.10.0"
+current_version = "0.10.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/src/laser/measles/__init__.py
+++ b/src/laser/measles/__init__.py
@@ -6,7 +6,7 @@ using agent-based and compartmental models with various spatial and temporal con
 """
 
 # ruff: noqa: F401, F403, E402
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 
 # --- Exports ---
 MEASLES_MODULES = ["laser.measles.abm", "laser.measles.compartmental", "laser.measles.biweekly"]


### PR DESCRIPTION
- laser-core>=1.0.0 → >=1.0.1
- appdirs>=1.4 → >=1.4.4 
- pydantic>=2.0 → >=2.12.5 
- pycountry>=22.3 → >=26.2.16
- polars>=1.0.0 → >=1.39.3
- patito>=0.8 → >=0.8.6 
- pytest-order>=1.1.1 → >=1.3.0
- notebook>=7.4.3 → >=7.5.5
- optuna>=4.4.0 → >=4.8.0 