### PR TITLE
fix: restore uint32 dtype for states arrays and update docstring

### DIFF
--- a/src/laser/measles/abm/model.py
+++ b/src/laser/measles/abm/model.py
@@ -89,7 +89,7 @@ class ABMModel(BaseLaserModel):
 
         self.patches = PatchLaserFrame(capacity=len(scenario))
         # Create the state vector for each of the patches
-        self.patches.states = StateArray(state_names=self.params.states, shape=(len(self.params.states), len(scenario)), state_axis=0)
+        self.patches.states = StateArray(state_names=self.params.states, shape=(len(self.params.states), len(scenario)), state_axis=0, dtype=np.uint32)
 
         # Start with totally susceptible population
         self.patches.states.S[:] = scenario["pop"]  # All susceptible initially

--- a/src/laser/measles/biweekly/model.py
+++ b/src/laser/measles/biweekly/model.py
@@ -59,7 +59,7 @@ class BiweeklyModel(BaseLaserModel):
         self.patches = PatchLaserFrame(capacity=len(scenario))
 
         # Create the state vector for each of the patches
-        self.patches.states = StateArray(state_names=self.params.states, shape=(len(self.params.states), len(scenario)), state_axis=0)
+        self.patches.states = StateArray(state_names=self.params.states, shape=(len(self.params.states), len(scenario)), state_axis=0, dtype=np.uint32)
 
         # Start with totally susceptible population
         self.patches.states.S[:] = scenario["pop"]

--- a/src/laser/measles/compartmental/model.py
+++ b/src/laser/measles/compartmental/model.py
@@ -98,6 +98,7 @@ class CompartmentalModel(BaseLaserModel):
             state_names=self.params.states,
             shape=(len(self.params.states), len(scenario)),
             state_axis=0,
+            dtype=np.uint32,
         )
 
         # Start with totally susceptible population

--- a/src/laser/measles/utils.py
+++ b/src/laser/measles/utils.py
@@ -196,7 +196,7 @@ class StateArray(np.ndarray):
     numeric indexing (e.g., states[0], states[1]).
 
     Example:
-        >>> states = StateArray(np.zeros((3, 100)), state_names=["S", "I", "R"])
+        >>> states = StateArray(state_names=["S", "I", "R"], state_axis=0, shape=(3, 100))
         >>> states.S[0] = 1000  # Set susceptible population in patch 0
         >>> prevalence = states.I / states.sum(axis=0)  # Calculate prevalence
         >>> states[0] += births  # Numeric indexing still works


### PR DESCRIPTION
## Fixes for PR #186

This PR targets the `cl/state-array-updates` branch and addresses two issues found during review:

### 🔴 dtype silently changed from `uint32` → `int32`

The refactor from `add_array_property()` + `StateArray` wrapping to direct `StateArray` allocation changed the states dtype:

- **Before:** `LaserFrame.add_array_property()` defaulted to `uint32` → `StateArray` wrapping preserved it
- **After:** `StateArray.__new__()` defaults to `int32` → all states arrays are now `int32`

This halves the max representable population (2.1B vs 4.3B) and changes the dtype propagated via `cast_type(value, patches.states.dtype)` throughout all components. Code that guards against `uint32` underflow (e.g., `process_vital_dynamics.py:77`) would also behave differently.

**Fix:** Added explicit `dtype=np.uint32` to all three model `StateArray(...)` calls (`abm/model.py`, `biweekly/model.py`, `compartmental/model.py`).

### 🟡 Stale docstring example

The `StateArray` class docstring example still used the old constructor signature. Updated to match the new API.

### Test results

All 286 unit tests pass (69 StateArray + 217 others).