### PR TITLE
Bump doc generation to Python 3.12

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -32,6 +32,8 @@ jobs:
       Sign Python 🐍 distribution 📦 with Sigstore and make GitHub Release
     needs: build
     runs-on: ubuntu-latest
+    environment:
+      name: restricted # remove if v* tag protection is enabled with GitHub App as sole bypass
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
       id-token: write  # IMPORTANT: mandatory for sigstore

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help docs-build docs-executed-nbs docs-jenner clean-docs
 
-PYTHON     ?= python3.11
+PYTHON     ?= python3.12
 SITE_DIR   ?= dist/mkdocs
 NBS_SRC    := docs/tutorials
 EXEC_DIR   ?= dist/executed_nbs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Utilities",
 ]


### PR DESCRIPTION
Include 𝝅-thon support (3.14)
Require authorization for releases (and publishing)