### PR TITLE
Fix snapshot docstrings: Google-style/MkDocs syntax, examples, type hint

### DIFF
--- a/src/laser/measles/abm/model.py
+++ b/src/laser/measles/abm/model.py
@@ -211,22 +211,40 @@ class ABMModel(BaseLaserModel):
 
     @classmethod
     def from_snapshot(cls, path, params: "ABMParams", components: list | None = None, verbose: bool = True) -> "ABMModel":
-        """
-        Restore an :class:`ABMModel` from an HDF5 snapshot file.
+        """Restore an ABMModel from an HDF5 snapshot file.
 
-        Convenience wrapper around :func:`laser.measles.abm.snapshot.load_snapshot`.
+        Convenience wrapper around
+        [`load_snapshot`][laser.measles.abm.snapshot.load_snapshot].  Use
+        this to resume a simulation from a checkpoint saved with
+        [`save_snapshot`][laser.measles.abm.snapshot.save_snapshot].
 
         Args:
-            path: Path to the HDF5 file written by :func:`save_snapshot`.
-            params: :class:`ABMParams` for the resumed segment.  Set
-                ``start_time`` to the snapshot date and ``num_ticks`` to the
-                remaining simulation duration.
+            path: Path to the HDF5 file written by
+                [`save_snapshot`][laser.measles.abm.snapshot.save_snapshot].
+            params: [`ABMParams`][laser.measles.abm.params.ABMParams] for the
+                resumed segment.  Set ``start_time`` to the snapshot date and
+                ``num_ticks`` to the remaining simulation duration.
             components: Ordered list of component *classes* — same as the
                 original model.
             verbose: Print a loading summary.
 
         Returns:
-            A configured :class:`ABMModel` ready for ``model.run()``.
+            A configured [`ABMModel`][laser.measles.abm.model.ABMModel]
+                ready for ``model.run()``.
+
+        **Example:**
+
+            ```python
+            import laser.measles as lm
+
+            params2 = lm.ABMParams(num_ticks=1825, seed=42, start_time="2009-12")
+            model2 = lm.ABMModel.from_snapshot(
+                "checkpoint.h5",
+                params2,
+                components=[lm.VitalDynamicsProcess, lm.InfectionProcess],
+            )
+            model2.run()
+            ```
         """
         from laser.measles.abm.snapshot import load_snapshot  # noqa: PLC0415
 

--- a/src/laser/measles/abm/snapshot.py
+++ b/src/laser/measles/abm/snapshot.py
@@ -54,20 +54,43 @@ def save_snapshot(
     squash_recovered: bool = True,
     verbose: bool = True,
 ) -> None:
-    """
-    Save ABM state to an HDF5 snapshot file.
+    """Save ABM state to an HDF5 snapshot file.
 
-    .. warning::
-        This function **mutates** ``model``: recovered agents are squashed (if
-        ``squash_recovered=True``) and future vaccination dates are normalized.
-        Do not continue running the model after calling this function.
+    Call this after [`ABMModel.run()`][laser.measles.abm.model.ABMModel.run]
+    to persist the full population and patch state.  The resulting HDF5 file
+    can be resumed with
+    [`load_snapshot`][laser.measles.abm.snapshot.load_snapshot] to continue
+    the simulation from exactly where it left off — useful for warm-start
+    parameter sweeps, segmented cluster jobs, or reproducible checkpoints.
+
+    Warning:
+        This function **mutates** ``model``: recovered agents are squashed
+        (if ``squash_recovered=True``) and future vaccination dates are
+        normalized.  Do not continue running the model after calling this
+        function.
 
     Args:
-        model: A fully-run (or mid-run) :class:`ABMModel` instance.
+        model: A fully-run (or mid-run)
+            [`ABMModel`][laser.measles.abm.model.ABMModel] instance.
         path: Destination HDF5 file path (created or overwritten).
-        squash_recovered: If ``True`` (default), remove recovered agents before
-            saving.  This dramatically reduces file size for long measles runs.
+        squash_recovered: If ``True`` (default), remove recovered agents
+            before saving.  This dramatically reduces file size for long
+            measles runs.
         verbose: Print a progress summary.
+
+    **Example:**
+
+        ```python
+        import laser.measles as lm
+
+        params = lm.ABMParams(num_ticks=3650, seed=42, start_time="2000-01")
+        model = lm.ABMModel(scenario, params)
+        model.components = [lm.VitalDynamicsProcess, lm.InfectionProcess]
+        model.run()
+
+        lm.save_snapshot(model, "checkpoint.h5")
+        # Do not use model after this point.
+        ```
     """
     path = Path(path)
 
@@ -157,23 +180,43 @@ def load_snapshot(
     components: list | None = None,
     verbose: bool = True,
 ) -> ABMModel:
-    """
-    Load an ABM from an HDF5 snapshot file and return it ready to run.
+    """Load an ABM from an HDF5 snapshot file and return it ready to run.
+
+    Restores the population, patch state, scenario, and metadata saved by
+    [`save_snapshot`][laser.measles.abm.snapshot.save_snapshot].  Components
+    that modify the people frame (e.g.
+    [`VitalDynamicsProcess`][laser.measles.abm.components.VitalDynamicsProcess])
+    detect the snapshot context via ``model._from_snapshot`` and skip frame
+    setup.  Set ``params.start_time`` to the snapshot date printed by
+    ``save_snapshot``.
 
     Args:
-        path: Path to the HDF5 snapshot file written by :func:`save_snapshot`.
-        params: :class:`ABMParams` for the resumed segment.  Set
-            ``start_time`` to the snapshot date (printed by ``save_snapshot``
-            or ``load_snapshot``) and ``num_ticks`` to the remaining duration.
+        path: Path to the HDF5 snapshot file written by
+            [`save_snapshot`][laser.measles.abm.snapshot.save_snapshot].
+        params: [`ABMParams`][laser.measles.abm.params.ABMParams] for the
+            resumed segment.  Set ``start_time`` to the snapshot date and
+            ``num_ticks`` to the remaining duration.
         components: Ordered list of component *classes* to attach — same list
-            as used when building the original model.  Components that modify
-            the people frame (e.g. ``VitalDynamicsProcess``) detect the
-            snapshot context via ``model._from_snapshot`` and skip frame setup.
+            as used when building the original model.
         verbose: Print a loading summary.
 
     Returns:
-        A configured :class:`ABMModel` instance.  Call ``model.run()`` to
-        continue the simulation.
+        A configured [`ABMModel`][laser.measles.abm.model.ABMModel] instance.
+            Call ``model.run()`` to continue the simulation.
+
+    **Example:**
+
+        ```python
+        import laser.measles as lm
+
+        params2 = lm.ABMParams(num_ticks=1825, seed=42, start_time="2009-12")
+        model2 = lm.load_snapshot(
+            "checkpoint.h5",
+            params2,
+            components=[lm.VitalDynamicsProcess, lm.InfectionProcess],
+        )
+        model2.run()
+        ```
     """
     from laser.measles.abm.base import PeopleLaserFrame  # noqa: PLC0415
     from laser.measles.abm.model import ABMModel  # noqa: PLC0415

--- a/src/laser/measles/compartmental/model.py
+++ b/src/laser/measles/compartmental/model.py
@@ -156,9 +156,43 @@ class CompartmentalModel(BaseLaserModel):
 
     @classmethod
     def from_snapshot(
-        cls, path: str | Path, params: CompartmentalParams, components: list[str] | None = None, verbose: bool = True
+        cls, path: str | Path, params: CompartmentalParams, components: list | None = None, verbose: bool = True
     ) -> "CompartmentalModel":
-        """Load a CompartmentalModel from an HDF5 snapshot (alias for load_snapshot)."""
+        """Load a CompartmentalModel from an HDF5 snapshot.
+
+        Convenience wrapper around
+        [`load_snapshot`][laser.measles.compartmental.snapshot.load_snapshot].
+        Use this to resume a simulation from a checkpoint saved with
+        [`save_snapshot`][laser.measles.compartmental.snapshot.save_snapshot].
+
+        Args:
+            path: Path to the HDF5 file written by
+                [`save_snapshot`][laser.measles.compartmental.snapshot.save_snapshot].
+            params:
+                [`CompartmentalParams`][laser.measles.compartmental.params.CompartmentalParams]
+                for the resumed segment.
+            components: Ordered list of component *classes* — same as the
+                original model, minus ``InfectionSeedingProcess``.
+            verbose: Print a loading summary.
+
+        Returns:
+            A configured
+                [`CompartmentalModel`][laser.measles.compartmental.model.CompartmentalModel]
+                ready for ``model.run()``.
+
+        **Example:**
+
+            ```python
+            import laser.measles as lm
+            from laser.measles.compartmental.components import InfectionProcess
+
+            params2 = lm.CompartmentalParams(num_ticks=365, seed=42, start_time="2001-01")
+            model2 = lm.CompartmentalModel.from_snapshot(
+                "checkpoint.h5", params2, components=[InfectionProcess]
+            )
+            model2.run()
+            ```
+        """
         from laser.measles.compartmental.snapshot import load_snapshot  # noqa: PLC0415
 
         return load_snapshot(path, params, components=components, verbose=verbose)

--- a/src/laser/measles/compartmental/snapshot.py
+++ b/src/laser/measles/compartmental/snapshot.py
@@ -52,13 +52,39 @@ def save_snapshot(
     path: str | Path,
     verbose: bool = True,
 ) -> None:
-    """
-    Save compartmental model patch state to an HDF5 snapshot file.
+    """Save compartmental model patch state to an HDF5 snapshot file.
+
+    Call this after
+    [`CompartmentalModel.run()`][laser.measles.compartmental.model.CompartmentalModel]
+    to persist the full patch SEIR state.  The resulting HDF5 file can be
+    resumed with
+    [`load_snapshot`][laser.measles.compartmental.snapshot.load_snapshot] to
+    continue the simulation from exactly where it left off.
 
     Args:
-        model: A fully-run (or mid-run) :class:`CompartmentalModel` instance.
+        model: A fully-run (or mid-run)
+            [`CompartmentalModel`][laser.measles.compartmental.model.CompartmentalModel]
+            instance.
         path: Destination HDF5 file path (created or overwritten).
         verbose: Print a progress summary.
+
+    **Example:**
+
+        ```python
+        import laser.measles as lm
+        from laser.measles.compartmental import save_snapshot
+        from laser.measles.compartmental.components import (
+            InfectionSeedingProcess,
+            InfectionProcess,
+        )
+
+        params = lm.CompartmentalParams(num_ticks=365, seed=42, start_time="2000-01")
+        model = lm.CompartmentalModel(scenario, params)
+        model.components = [InfectionSeedingProcess, InfectionProcess]
+        model.run()
+
+        save_snapshot(model, "checkpoint.h5")
+        ```
     """
     path = Path(path)
 
@@ -108,23 +134,45 @@ def load_snapshot(
     components: list | None = None,
     verbose: bool = True,
 ) -> CompartmentalModel:
-    """
-    Load a compartmental model from an HDF5 snapshot file and return it ready to run.
+    """Load a compartmental model from an HDF5 snapshot file and return it ready to run.
+
+    Restores the patch SEIR state, scenario, and metadata saved by
+    [`save_snapshot`][laser.measles.compartmental.snapshot.save_snapshot].
+    Set ``params.start_time`` to the snapshot date printed by
+    ``save_snapshot``.  Do **not** include ``InfectionSeedingProcess`` in the
+    ``components`` list — infections are already encoded in the restored
+    patch states.
 
     Args:
-        path: Path to the HDF5 snapshot file written by :func:`save_snapshot`.
-        params: :class:`CompartmentalParams` for the resumed segment.  Set
-            ``start_time`` to the snapshot date and ``num_ticks`` to the
-            remaining duration.
+        path: Path to the HDF5 snapshot file written by
+            [`save_snapshot`][laser.measles.compartmental.snapshot.save_snapshot].
+        params:
+            [`CompartmentalParams`][laser.measles.compartmental.params.CompartmentalParams]
+            for the resumed segment.  Set ``start_time`` to the snapshot date
+            and ``num_ticks`` to the remaining duration.
         components: Ordered list of component *classes* to attach — same list
             as used when building the original model, minus
-            ``InfectionSeedingProcess`` (infections are already in the
-            restored patch states).
+            ``InfectionSeedingProcess``.
         verbose: Print a loading summary.
 
     Returns:
-        A configured :class:`CompartmentalModel` instance.  Call
-        ``model.run()`` to continue the simulation.
+        A configured
+            [`CompartmentalModel`][laser.measles.compartmental.model.CompartmentalModel]
+            instance.  Call ``model.run()`` to continue the simulation.
+
+    **Example:**
+
+        ```python
+        import laser.measles as lm
+        from laser.measles.compartmental import load_snapshot
+        from laser.measles.compartmental.components import InfectionProcess
+
+        params2 = lm.CompartmentalParams(num_ticks=365, seed=42, start_time="2001-01")
+        model2 = load_snapshot(
+            "checkpoint.h5", params2, components=[InfectionProcess]
+        )
+        model2.run()
+        ```
     """
     from laser.measles.compartmental.model import CompartmentalModel  # noqa: PLC0415
 


### PR DESCRIPTION
Follow-up to #192 — fixes docstring compliance issues for the new snapshot API.

## Changes

### Sphinx → Google-style/MkDocs directives
The snapshot docstrings used Sphinx RST syntax (`.. warning::`, `:class:`, `:func:`) which won't render correctly with the project's mkdocstrings configuration (`docstring_style: google`). Converted to:
- `Warning:` sections (Google-style)
- `[`text`][module.path]` cross-references (MkDocs autorefs)

### Added `Example:` sections
Per the project docstring guidelines, all public functions and classmethods now include `Example:` sections showing the researcher workflow.

### Added researcher workflow context
Each docstring now explains where the function fits in the save → resume lifecycle and links to related functions.

### Fixed `CompartmentalModel.from_snapshot` type hint
`components: list[str]` → `components: list` — components are classes, not strings.

## Files changed
- `src/laser/measles/abm/snapshot.py` — `save_snapshot`, `load_snapshot`
- `src/laser/measles/abm/model.py` — `ABMModel.from_snapshot`
- `src/laser/measles/compartmental/snapshot.py` — `save_snapshot`, `load_snapshot`
- `src/laser/measles/compartmental/model.py` — `CompartmentalModel.from_snapshot`