### PR TITLE
Add type hints to function signatures (alternative to #193 docstring types)

### DIFF
--- a/src/laser/measles/abm/components/process_infection.py
+++ b/src/laser/measles/abm/components/process_infection.py
@@ -103,7 +103,7 @@ class InfectionProcess(BaseInfectionProcess):
         self.transmission = TransmissionProcess(model, verbose, self.params.transmission_params)
         self.disease = DiseaseProcess(model, verbose, self.params.disease_params)
 
-    def __call__(self, model, tick: int) -> None:
+    def __call__(self, model: ABMModel, tick: int) -> None:
         """
         Execute both transmission and disease progression for the given tick.
 

--- a/src/laser/measles/abm/components/process_transmission.py
+++ b/src/laser/measles/abm/components/process_transmission.py
@@ -13,6 +13,7 @@ from laser.measles.base import BasePhase
 from laser.measles.migration import init_gravity_diffusion
 from laser.measles.mixing.gravity import GravityMixing
 from laser.measles.utils import cast_type
+from laser.measles.utils import matmul
 
 # Import numba conditionally for the numba implementation
 try:
@@ -195,7 +196,8 @@ class TransmissionProcess(BasePhase):
         # transfer between and w/in patches
         # NB: this assumes that the mixing matrix is properly normalized
         # i.e., that the sum of each row is 1 (self.mixing.sum(axis=1) == 1)
-        forces = (beta_effective * patches.states.I) @ self.params.mixer.mixing_matrix
+        # forces = (beta_effective * patches.states.I) @ self.params.mixer.mixing_matrix
+        forces = matmul(beta_effective * patches.states.I, self.params.mixer.mixing_matrix)
 
         # normalize by the population of the patch
         forces /= patches.states.sum(axis=0)

--- a/src/laser/measles/base.py
+++ b/src/laser/measles/base.py
@@ -229,7 +229,7 @@ class BaseLaserModel(ABC):
         """
         self.tinit = datetime.now(tz=None)  # noqa: DTZ005
         if params.verbose:
-            print(f"{self.tinit}: Creating the {name} model…")
+            print(f"{self.tinit}: Creating the {name} model\u2026")
 
         # Auto-wrap polars DataFrame in appropriate scenario class if needed
         if isinstance(scenario, pl.DataFrame) and self.scenario_wrapper_class is not None:
@@ -388,7 +388,7 @@ class BaseLaserModel(ABC):
         num_ticks = self.params.num_ticks
         self._tstart = datetime.now(tz=None)  # noqa: DTZ005
         if self.params.verbose:
-            print(f"{self._tstart}: Running the {self.name} model for {num_ticks} ticks…")
+            print(f"{self._tstart}: Running the {self.name} model for {num_ticks} ticks\u2026")
 
         self.metrics = []
 
@@ -405,7 +405,7 @@ class BaseLaserModel(ABC):
 
         self._tfinish = datetime.now(tz=None)  # noqa: DTZ005
         if self.params.verbose:
-            print(f"Completed the {self.name} model at {self._tfinish}…")
+            print(f"Completed the {self.name} model at {self._tfinish}\u2026")
             self._print_timing_summary()
 
     def time_elapsed(self, units: str = "days") -> int | float:
@@ -554,7 +554,7 @@ class BaseLaserModel(ABC):
                 for _plot in instance.plot():
                     plt.show()
         else:
-            print("Generating PDF output…")
+            print("Generating PDF output\u2026")
             pdf_filename = f"{self.name} {self._tstart:%Y-%m-%d %H%M%S}.pdf"
             with PdfPages(pdf_filename) as pdf_file:
                 for instance in self.instances:
@@ -615,7 +615,7 @@ class BaseLaserModel(ABC):
             sum_columns = metrics[plot_columns].sum()
             width = max(map(len, sum_columns.index))
             for key in sum_columns.index:
-                print(f"{key:{width}}: {sum_columns[key]:13,} µs")
+                print(f"{key:{width}}: {sum_columns[key]:13,} \u00b5s")
             print("=" * (width + 2 + 13 + 3))
             print(f"{'Total:':{width + 1}} {sum_columns.sum():13,} microseconds")
         except ImportError:
@@ -729,7 +729,7 @@ class BasePhase(BaseComponent):
     """
 
     @abstractmethod
-    def __call__(self, model, tick: int) -> None:
+    def __call__(self, model: Any, tick: int) -> None:
         """
         Execute component logic for a given simulation tick.
 
@@ -760,7 +760,7 @@ class BaseScenario(ABC):
         """
         self._df = df
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr: str) -> Any:
         """
         Forward attribute access to the underlying DataFrame.
 
@@ -773,7 +773,7 @@ class BaseScenario(ABC):
         # Forward attribute access to the underlying DataFrame
         return getattr(self._df, attr)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: Any) -> Any:
         """
         Forward item access to the underlying DataFrame.
 
@@ -785,7 +785,7 @@ class BaseScenario(ABC):
         """
         return self._df[key]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Return string representation of the scenario.
 
@@ -794,7 +794,7 @@ class BaseScenario(ABC):
         """
         return repr(self._df)
 
-    def __len__(self):
+    def __len__(self) -> int:
         """
         Return the length of the underlying DataFrame.
 

--- a/src/laser/measles/biweekly/components/process_importation_pressure.py
+++ b/src/laser/measles/biweekly/components/process_importation_pressure.py
@@ -173,7 +173,7 @@ class ImportationPressureProcess(BasePhase):
         self.params = params or ImportationPressureParams()
         self.patch_rates_per_year_per_1k: np.ndarray | None = None
 
-    def __call__(self, model, tick: int) -> None:
+    def __call__(self, model: BiweeklyModel, tick: int) -> None:
         """
         Process importation pressure for the current tick.
 

--- a/src/laser/measles/biweekly/components/process_infection.py
+++ b/src/laser/measles/biweekly/components/process_infection.py
@@ -7,6 +7,7 @@ from laser.measles.base import BaseLaserModel
 from laser.measles.components import BaseInfectionParams
 from laser.measles.components import BaseInfectionProcess
 from laser.measles.mixing.gravity import GravityMixing
+from laser.measles.utils import matmul
 
 
 class InfectionParams(BaseInfectionParams):
@@ -78,11 +79,17 @@ class InfectionProcess(BaseInfectionProcess):
         # prevalence in each patch
         prevalence = states.I  # / states.sum(axis=0)  # I_j / N_j
 
-        lambda_i = (
+        # lambda_i = (
+        #     self.params.beta_per_tick
+        #     * (1 + self.params.seasonality * np.sin(2 * np.pi * (tick - self.params.season_start) / 26.0))
+        #     * prevalence
+        # ) @ self.params.mixer.mixing_matrix
+        lambda_i = matmul(
             self.params.beta_per_tick
             * (1 + self.params.seasonality * np.sin(2 * np.pi * (tick - self.params.season_start) / 26.0))
-            * prevalence
-        ) @ self.params.mixer.mixing_matrix
+            * prevalence,
+            self.params.mixer.mixing_matrix,
+        )
 
         # normalize by the population of the patch
         lambda_i /= states.sum(axis=0)

--- a/src/laser/measles/compartmental/components/process_infection.py
+++ b/src/laser/measles/compartmental/components/process_infection.py
@@ -12,6 +12,7 @@ from laser.measles.components import BaseInfectionParams
 from laser.measles.components import BaseInfectionProcess
 from laser.measles.mixing.gravity import GravityMixing
 from laser.measles.utils import cast_type
+from laser.measles.utils import matmul
 
 
 class InfectionParams(BaseInfectionParams):
@@ -134,9 +135,10 @@ class InfectionProcess(BaseInfectionProcess):
 
         # Calculate force of infection with seasonal variation
         seasonal_factor = 1 + self.params.seasonality * np.sin(2 * np.pi * (tick - self.params.season_start) / 365.0)
-        lambda_i = (
-            (self.params.beta * seasonal_factor * prevalence) @ self.params.mixer.mixing_matrix  # recall mixing is pij: i -> j
-        )
+        # lambda_i = (
+        #     (self.params.beta * seasonal_factor * prevalence) @ self.params.mixer.mixing_matrix  # recall mixing is pij: i -> j
+        # )
+        lambda_i = matmul(self.params.beta * seasonal_factor * prevalence, self.params.mixer.mixing_matrix)  # recall mixing is pij: i -> j
 
         # normalize by the population of the patch
         lambda_i /= total_patch_pop

--- a/src/laser/measles/components/base_case_surveillance.py
+++ b/src/laser/measles/components/base_case_surveillance.py
@@ -49,7 +49,7 @@ class BaseCaseSurveillanceTracker(BasePhase):
         params: Component-specific parameters. If None, will use default parameters.
     """
 
-    def __init__(self, model, verbose: bool = False, params: BaseCaseSurveillanceParams | None = None) -> None:
+    def __init__(self, model: BaseLaserModel, verbose: bool = False, params: BaseCaseSurveillanceParams | None = None) -> None:
         super().__init__(model, verbose)
         self.params = params or BaseCaseSurveillanceParams()
         self._validate_params()
@@ -85,7 +85,7 @@ class BaseCaseSurveillanceTracker(BasePhase):
         if self.params.aggregation_level < -1:
             raise ValueError("aggregation_level must be at least -1")
 
-    def __call__(self, model, tick: int) -> None:
+    def __call__(self, model: BaseLaserModel, tick: int) -> None:
         """Process case surveillance for the current tick.
 
         Args:

--- a/src/laser/measles/components/base_tracker_fadeout.py
+++ b/src/laser/measles/components/base_tracker_fadeout.py
@@ -34,11 +34,11 @@ class BaseFadeOutTracker(BasePhase):
         verbose (bool, optional): Whether to enable verbose logging. Defaults to False.
     """
 
-    def __init__(self, model, verbose: bool = False) -> None:
+    def __init__(self, model: BaseLaserModel, verbose: bool = False) -> None:
         super().__init__(model, verbose)
         self.fade_out_tracker = np.zeros(model.params.num_ticks)
 
-    def __call__(self, model, tick: int) -> None:
+    def __call__(self, model: BaseLaserModel, tick: int) -> None:
         self.fade_out_tracker[tick] = np.sum(model.patches.states.I == 0)  # number of nodes with 0 in I state
 
     def initialize(self, model: BaseLaserModel) -> None:

--- a/src/laser/measles/components/base_tracker_state.py
+++ b/src/laser/measles/components/base_tracker_state.py
@@ -156,11 +156,10 @@ class BaseStateTracker(BasePhase):
         in each state changes over time. Each state gets its own subplot for better visibility.
 
         Parameters:
-            fig (Figure, optional): A matplotlib Figure object. If None, a new figure will be created.
+            fig (Figure | None): A matplotlib Figure object. If None, a new figure will be created.
 
         Yields:
-            None: This function uses a generator to yield control back to the caller.
-            If used directly (not as a generator), it will show the plot immediately.
+            (None): Yields control back to the caller once after preparing the figure, so it can be used in generator-based visualization workflows. The caller is responsible for displaying the plot, for example by calling `plt.show()`.
 
         Example:
             # Use as a generator (for model.visualize()):
@@ -204,10 +203,10 @@ class BaseStateTracker(BasePhase):
         Plots all SEIR states on a single plot for easy comparison.
 
         Parameters:
-            fig (Figure, optional): A matplotlib Figure object. If None, a new figure will be created.
+            fig (Figure | None): A matplotlib Figure object. If None, a new figure will be created.
 
         Yields:
-            None: This function uses a generator to yield control back to the caller.
+            (None): This function uses a generator to yield control back to the caller.
         """
         fig = plt.figure(figsize=(12, 6), dpi=128) if fig is None else fig
 

--- a/src/laser/measles/components/base_tracker_state.py
+++ b/src/laser/measles/components/base_tracker_state.py
@@ -63,7 +63,7 @@ class BaseStateTracker(BasePhase):
         params: Component-specific parameters. If None, will use default parameters.
     """
 
-    def __init__(self, model, verbose: bool = False, params: BaseStateTrackerParams | None = None) -> None:
+    def __init__(self, model: BaseLaserModel, verbose: bool = False, params: BaseStateTrackerParams | None = None) -> None:
         super().__init__(model, verbose)
         self.name = "StateTracker"
         self.params = params or BaseStateTrackerParams()
@@ -131,7 +131,7 @@ class BaseStateTracker(BasePhase):
             # Return (num_ticks, num_groups)
             return self.state_tracker[state_idx, :, :]
 
-    def __call__(self, model, tick: int) -> None:
+    def __call__(self, model: BaseLaserModel, tick: int) -> None:
         if self.params.aggregation_level >= 0:
             # For each group, aggregate states from its nodes
             for group_idx, (_, node_indices) in enumerate(self.node_mapping.items()):

--- a/src/laser/measles/components/base_transmission.py
+++ b/src/laser/measles/components/base_transmission.py
@@ -11,6 +11,7 @@ import numpy as np
 from pydantic import BaseModel
 from pydantic import Field
 
+from ..base import BaseLaserModel
 from ..base import BasePhase
 
 
@@ -45,7 +46,7 @@ class BaseTransmission(BasePhase, ABC):
     mathematical approach (agent-based, compartmental, etc.).
     """
 
-    def __init__(self, model, verbose: bool = False, params: BaseTransmissionParams | None = None):
+    def __init__(self, model: BaseLaserModel, verbose: bool = False, params: BaseTransmissionParams | None = None):
         """Initialize the transmission component.
 
         Args:
@@ -61,7 +62,7 @@ class BaseTransmission(BasePhase, ABC):
             np.random.seed(self.params.random_seed)
 
     @abstractmethod
-    def __call__(self, model, tick: int):
+    def __call__(self, model: BaseLaserModel, tick: int):
         """Execute transmission dynamics for one time step.
 
         This method must be implemented by each model type to define
@@ -72,7 +73,7 @@ class BaseTransmission(BasePhase, ABC):
             tick: Current time step
         """
 
-    def get_force_of_infection(self, model, tick: int) -> np.ndarray:
+    def get_force_of_infection(self, model: BaseLaserModel, tick: int) -> np.ndarray:
         """Calculate force of infection for each patch.
 
         This method provides a common interface for calculating

--- a/src/laser/measles/demographics/admin_shapefile.py
+++ b/src/laser/measles/demographics/admin_shapefile.py
@@ -15,7 +15,7 @@ class AdminShapefile(BaseShapefile):
     """
     Shapefile of administrative units.
 
-    Args:
+    Attributes:
         admin_level (int): Admin level of the shapefile.
         dotname_fields (list[str]): List of fields to use for dotname. e.g., ["ADMIN0", "ADMIN1", "ADMIN2"]
     """

--- a/src/laser/measles/migration.py
+++ b/src/laser/measles/migration.py
@@ -4,7 +4,7 @@ import numpy as np
 import polars as pl
 
 
-def pairwise_haversine(df):  # TODO: use angular separation formula instead
+def pairwise_haversine(df: pl.DataFrame) -> np.ndarray:  # TODO: use angular separation formula instead
     """Pairwise distances for all (lon, lat) points using the Haversine formula.
 
     Args:

--- a/src/laser/measles/mixing/gravity.py
+++ b/src/laser/measles/mixing/gravity.py
@@ -15,7 +15,7 @@ class GravityParams(BaseModel):
         .. math::
             M_{i,j} = k \\cdot p_i^{a-1} \\cdot p_j^b \\cdot d_{i,j}^{-c}
 
-    Args:
+    Attributes:
         a (float): Population source scale parameter
         b (float): Population target scale parameter
         c (float): Distance exponent
@@ -55,7 +55,7 @@ class GravityMixing(BaseMixing):
 
     Examples
     --------
-    Typical usage — let the model set the scenario automatically:
+    Typical usage \u2014 let the model set the scenario automatically:
 
     .. code-block:: python
 

--- a/src/laser/measles/mixing/radiation.py
+++ b/src/laser/measles/mixing/radiation.py
@@ -11,7 +11,7 @@ class RadiationParams(BaseModel):
     """
     Parameters for the radiation migration model.
 
-    Args:
+    Attributes:
         include_home (bool): Whether to include home in the migration matrix
         k (float): Scale parameter (avg trip probability)
 
@@ -30,7 +30,7 @@ class RadiationMixing(BaseMixing):
         .. math::
             M_{i,j} = k \\frac{p_i p_j}{\\left(p_i + \\sum_{k \\in \\Omega(i,j)} p_k\\right)\\left(p_i + p_j + \\sum_{k \\in \\Omega(i,j)} p_k\\right)}
 
-    Args:
+    Attributes:
         include_home (bool): Whether to include home in the migration matrix
         k (float): Scale parameter (avg trip probability)
     """

--- a/src/laser/measles/mixing/stouffer.py
+++ b/src/laser/measles/mixing/stouffer.py
@@ -11,9 +11,11 @@ class StoufferParams(BaseModel):
     """
     Parameters for the stouffer migration model.
 
-    Args:
+    Attributes:
         include_home (bool): Whether to include home in the migration matrix
         k (float): Scale parameter (avg trip probability)
+        a (float): Population source exponent
+        b (float): Population target exponent
 
     """
 
@@ -31,8 +33,10 @@ class StoufferMixing(BaseMixing):
         .. math::
             M_{i,j} = k p_i^a \\sum_j \\left(\\frac{p_j}{\\sum_{k \\in \\Omega(i,j)} p_k}\\right)^b
 
-    Args:
+    Attributes:
         include_home (bool): Whether to include home in the migration matrix
+        a (float): Population source exponent
+        b (float): Population target exponent
     """
 
     def __init__(self, scenario: pl.DataFrame | None = None, params: StoufferParams | None = None):

--- a/src/laser/measles/scenarios/synthetic.py
+++ b/src/laser/measles/scenarios/synthetic.py
@@ -249,7 +249,7 @@ def satellites_scenario(
     mcv1: float = 0.50,
     seed: int | None = 52,
     population_std: float = 0.3,
-):
+) -> pl.DataFrame:
     """
     Create a cluster of nodes with a single large node in the center (core) surrounded by smaller nodes (satellites).
 

--- a/src/laser/measles/utils.py
+++ b/src/laser/measles/utils.py
@@ -28,6 +28,7 @@ import os
 import warnings
 from collections.abc import Callable
 from functools import wraps
+from typing import Any
 
 import numpy as np
 from laser.core.laserframe import LaserFrame
@@ -105,9 +106,9 @@ def calc_capacity(population: np.uint32, nticks: np.uint32, cbr: np.float32, ver
     capacity = np.uint32(population * (1 + daily_rate) ** nticks)
 
     if verbose:
-        print(f"Population growth: {population:,} … {capacity:,}")
+        print(f"Population growth: {population:,} \u2026 {capacity:,}")
         alternate = np.uint32(population * (1 + cbr / 1000) ** (nticks / 365))
-        print(f"Alternate growth:  {population:,} … {alternate:,}")
+        print(f"Alternate growth:  {population:,} \u2026 {alternate:,}")
 
     return int(capacity)
 
@@ -166,7 +167,7 @@ def seed_infections_in_patch(model, ipatch: int, ninfections: int = 100) -> None
     return
 
 
-def cast_type(a, dtype, round: bool = False):
+def cast_type(a: Any, dtype: np.dtype, round: bool = False) -> Any:
     """
     Cast a value to a specified data type.
     Note that this casting truncates by default.

--- a/src/laser/measles/utils.py
+++ b/src/laser/measles/utils.py
@@ -25,6 +25,8 @@ Functions:
 """
 
 import os
+import platform
+import sys
 import warnings
 from collections.abc import Callable
 from functools import wraps
@@ -202,15 +204,6 @@ class StateArray(np.ndarray):
         >>> prevalence = states.I / states.sum(axis=0)  # Calculate prevalence
         >>> states[0] += births  # Numeric indexing still works
         >>> N = states.sum(axis=states.state_axis)  # Sum over state axis to get total population per patch
-
-    Args:
-        state_names: List or tuple of state compartment names (e.g., ["S", "E", "I", "R"])
-        state_axis: The axis along which the state compartments are stored
-        source_array: The numpy array to wrap
-        shape: The shape of the array if source_array is not provided
-        dtype: The data type of the array
-        default_value: The default value to fill the array with if source_array is not provided
-
     """
 
     def __new__(
@@ -222,6 +215,22 @@ class StateArray(np.ndarray):
         dtype=np.uint32,
         default_value=0,
     ):
+        """Create a new StateArray instance.
+
+        The StateArray can be created either by providing a source_array or by specifying the shape and default_value.
+        In either case the state_names and state_axis parameters are required. state_names defines the names of the state compartments, and state_axis specifies the axis along which these states are stored.
+
+        Args:
+            state_names (list[str] | tuple[str, ...]): List or tuple of state compartment names (e.g., ["S", "E", "I", "R"])
+            state_axis (int): The axis along which the state compartments are stored
+            source_array (np.ndarray | None): The numpy array to wrap
+            shape (tuple[int, ...] | None): The shape of the array if source_array is not provided
+            dtype (np.dtype): The data type of the array
+            default_value (number): The default value to fill the array with if source_array is not provided
+
+        Returns:
+            (StateArray): An instance of StateArray with the specified properties
+        """
 
         if (source_array is not None) and (shape is not None):
             raise ValueError("specify either source_array or shape, but not both")
@@ -435,3 +444,21 @@ def dual_implementation(numpy_func: Callable, numba_func: Callable) -> Callable:
     wrapper.numba_func = numba_func
 
     return wrapper
+
+
+# Certain NumPy implementations on MacOS with Apple Silicon link to Apple's math
+# libraries which erroneously raise a divide by zero warning on certain matmul
+# operations. Note that matmul doesn't involve a divide...
+# This only happens on MacOS Apple Silicon (arm64) on 3.10 (3.11 and higher user
+# later versions of NumPy which have a workaround).
+major, minor, *_ = sys.version_info
+if (major, minor) == (3, 10) and platform.system() == "Darwin" and platform.machine() == "arm64":
+
+    def matmul(v, m):
+        """Multiply a 1-D vector with a 2-D matrix"""
+        return (v[:, None] * m).sum(axis=0)
+else:
+
+    def matmul(v, m):
+        """Multiply a 1-D vector with a 2-D matrix"""
+        return v @ m


### PR DESCRIPTION
## Summary

Alternative approach to #193 for resolving `griffe` warnings about untyped parameters and return values. Instead of adding types to docstring `Args:` / `Returns:` sections, this PR adds proper Python type hints directly to function signatures. Also includes all other non-type-hint fixes from #193.

## Type hint changes (instead of docstring types)

### Parameter type hints added
| File | Method | Change |
|------|--------|--------|
| `base.py` | `BasePhase.__call__` | `model` → `model: Any` |
| `base.py` | `BaseScenario.__getattr__` | `attr` → `attr: str` |
| `base.py` | `BaseScenario.__getitem__` | `key` → `key: Any` |
| `abm/.../process_infection.py` | `InfectionProcess.__call__` | `model` → `model: ABMModel` |
| `biweekly/.../process_importation_pressure.py` | `ImportationPressureProcess.__call__` | `model` → `model: BiweeklyModel` |
| `components/base_case_surveillance.py` | `__init__`, `__call__` | `model` → `model: BaseLaserModel` |
| `components/base_tracker_fadeout.py` | `__init__`, `__call__` | `model` → `model: BaseLaserModel` |
| `components/base_tracker_state.py` | `__init__`, `__call__` | `model` → `model: BaseLaserModel` |
| `components/base_transmission.py` | `__init__`, `__call__`, `get_force_of_infection` | `model` → `model: BaseLaserModel` |
| `migration.py` | `pairwise_haversine` | `df` → `df: pl.DataFrame` |
| `utils.py` | `cast_type` | `a` → `a: Any`, `dtype` → `dtype: np.dtype` |

### Return type hints added
| File | Method | Return type |
|------|--------|-------------|
| `base.py` | `BaseScenario.__getattr__` | `-> Any` |
| `base.py` | `BaseScenario.__getitem__` | `-> Any` |
| `base.py` | `BaseScenario.__repr__` | `-> str` |
| `base.py` | `BaseScenario.__len__` | `-> int` |
| `migration.py` | `pairwise_haversine` | `-> np.ndarray` |
| `scenarios/synthetic.py` | `satellites_scenario` | `-> pl.DataFrame` |
| `utils.py` | `cast_type` | `-> Any` |

## Other fixes (from #193)

### `matmul` utility for Apple Silicon workaround
- Added `matmul(v, m)` function to `utils.py` that works around a NumPy divide-by-zero warning on macOS Apple Silicon with Python 3.10
- Replaced `@ self.params.mixer.mixing_matrix` with `matmul(...)` in:
  - `abm/components/process_transmission.py`
  - `biweekly/components/process_infection.py`
  - `compartmental/components/process_infection.py`

### Docstring `Args:` → `Attributes:` for Pydantic models
Griffe expects `Attributes:` (not `Args:`) for Pydantic `BaseModel` field docs:
- `demographics/admin_shapefile.py` — `AdminShapefile`
- `mixing/gravity.py` — `GravityParams`
- `mixing/radiation.py` — `RadiationParams`, `RadiationMixing`
- `mixing/stouffer.py` — `StoufferParams`, `StoufferMixing` (also added missing `a` and `b` field docs)

### StateArray docstring restructuring
- Moved `Args:` block from the class docstring to a new `__new__` method docstring (where the parameters actually live)

### Docstring wording improvements
- `base_tracker_state.py` — Updated `plot()` and `plot_combined()` parameter/yield docs

## Why type hints instead of docstring types?

- **griffe/mkdocstrings** can infer types from annotations, so the warnings are resolved
- Type hints are checked by mypy/pyright, docstring types are not
- Reduces duplication — the type is stated once in the signature rather than repeated in the docstring
- Follows the project's existing pattern (many methods already have type hints)

## Testing

All 286 existing tests pass.