### PR TITLE
Standardize verbose flag on model.params.verbose

### DIFF
--- a/docs/tutorials/tut_abm_vital_dynamics.py
+++ b/docs/tutorials/tut_abm_vital_dynamics.py
@@ -26,8 +26,8 @@ scenario = synthetic.two_patch_scenario()
 # %%
 from laser.measles.base import BasePhase
 class PeopleLengthTracker(BasePhase):
-    def __init__(self, model, verbose):
-        super().__init__(model, verbose=verbose)
+    def __init__(self, model):
+        super().__init__(model)
         self.laserframe_tracker = np.zeros((model.params.num_ticks,))
     def __call__(self, model, tick):
         self.laserframe_tracker[tick] = len(model.people)

--- a/docs/tutorials/tut_creating_component.py
+++ b/docs/tutorials/tut_creating_component.py
@@ -48,8 +48,8 @@ class PIRIProcess(BasePhase):
     temporarily boosting MCV1 coverage to improve routine immunization of newborns.
     """
 
-    def __init__(self, model, verbose: bool = False, params: PIRIParams | None = None):
-        super().__init__(model, verbose)
+    def __init__(self, model, params: PIRIParams | None = None):
+        super().__init__(model)
         self.params = params if params is not None else PIRIParams()
         self.original_mcv1 = None  # Store original MCV1 values
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -304,8 +304,8 @@ The component system provides a uniform interface for disease dynamics with inte
 from laser.measles.components.base_infection import BaseInfectionProcess
 
 class MyInfectionProcess(BaseInfectionProcess):
-    def __init__(self, model, verbose=False, **params):
-        super().__init__(model, verbose)
+    def __init__(self, model, **params):
+        super().__init__(model)
         # Initialize with validated parameters
 
 # Add to model
@@ -1364,24 +1364,29 @@ params = SIACalendarParams(aggregation_level=1, sia_schedule=schedule_df, ...)
 
 For hierarchical IDs like `"country:state:lga"`, use `aggregation_level=3`.
 
-### Custom components added via `add_component` must accept `verbose`
+### Custom components read verbosity from `model.params.verbose`
 
 `ABMModel.add_component(ComponentClass)` instantiates the class as
-`ComponentClass(model, verbose=False)`. Any custom component class must
-accept `verbose` as a keyword argument or the framework raises:
-
-```
-TypeError: MyTracker.__init__() got an unexpected keyword argument 'verbose'
-```
-
-Always include `verbose=False` in custom component `__init__`:
+`ComponentClass(model)` — components no longer take a `verbose` constructor
+kwarg. To gate logging on the model-level verbose flag, read
+`self.verbose` (a property on `BaseComponent` that mirrors
+`model.params.verbose`):
 
 ```python
-class MyTracker:
-    def __init__(self, model, verbose: bool = False):
-        self.model = model
+from laser.measles.base import BasePhase
+
+class MyTracker(BasePhase):
+    def __init__(self, model):
+        super().__init__(model)
         # ...
+
+    def __call__(self, model, tick):
+        if self.verbose:
+            print(f"tick {tick}: ...")
 ```
+
+Toggling `model.params.verbose` at any point during the run is immediately
+visible to every component; no kwarg threading is required.
 
 ### 25. `model.people` has `date_of_birth`, not `age`
 

--- a/src/laser/measles/abm/components/process_constant_pop.py
+++ b/src/laser/measles/abm/components/process_constant_pop.py
@@ -22,24 +22,22 @@ class ConstantPopProcess(BaseConstantPopProcess):
     Attributes:
 
         model: The model instance containing population and parameters.
-        verbose (bool): Flag to enable verbose output. Default is False.
         initializers (list): List of initializers to be called on birth events.
         metrics (DataFrame): DataFrame to holding timing metrics for initializers.
     """
 
-    def __init__(self, model: ABMModel, verbose: bool = False, params: ConstantPopParams | None = None):
+    def __init__(self, model: ABMModel, params: ConstantPopParams | None = None):
         """
         Initialize the Births component.
 
         Parameters:
 
             model (object): The model object which must have a `population` attribute.
-            verbose (bool, optional): If True, enables verbose output. Defaults to False.
             params (BirthsParams, optional): Component parameters. If None, uses model.params.
 
         """
 
-        super().__init__(model, verbose)
+        super().__init__(model)
 
         self.params = params if params is not None else ConstantPopParams()
 

--- a/src/laser/measles/abm/components/process_disease.py
+++ b/src/laser/measles/abm/components/process_disease.py
@@ -143,8 +143,8 @@ class DiseaseProcess(BaseComponent):
     It is used to update the infectious timers and the exposed timers.
     """
 
-    def __init__(self, model, verbose: bool = False, params: DiseaseParams | None = None):
-        super().__init__(model, verbose)
+    def __init__(self, model, params: DiseaseParams | None = None):
+        super().__init__(model)
         self.params = params if params is not None else DiseaseParams()
 
     def __call__(self, model, tick: int) -> None:

--- a/src/laser/measles/abm/components/process_importation.py
+++ b/src/laser/measles/abm/components/process_importation.py
@@ -5,8 +5,8 @@ Classes:
     Infect_Random_Agents: A class to periodically infect a random subset of agents in the population
 
 Functions:
-    Infect_Random_Agents.__init__(self, model, period, count, start, verbose: bool = False) -> None:
-        Initializes the Infect_Random_Agents class with a given model, period, count, and verbosity option.
+    Infect_Random_Agents.__init__(self, model, period, count, start) -> None:
+        Initializes the Infect_Random_Agents class with a given model, period, count, and start time.
 
     Infect_Random_Agents.__call__(self, model, tick) -> None:
         Checks whether it is time to infect a random subset of agents and infects them if necessary.
@@ -40,7 +40,7 @@ class InfectRandomAgentsProcess:
     A component to update the infection timers of a population in a model.
     """
 
-    def __init__(self, model, verbose: bool = False, params: ImportationParams | None = None) -> None:
+    def __init__(self, model, params: ImportationParams | None = None) -> None:
         """
         Initialize an Infect_Random_Agents instance.
 
@@ -50,7 +50,6 @@ class InfectRandomAgentsProcess:
             period: The number of ticks between each infection event.
             count: The number of agents to infect at each event.
             start (int, optional): The tick at which to start the infection events.
-            verbose (bool, optional): If True, enables verbose output. Defaults to False.
 
         Attributes:
 
@@ -114,7 +113,7 @@ class InfectAgentsInPatchProcess:
     A component to update the infection timers of a population in a model.
     """
 
-    def __init__(self, model, verbose: bool = False, params: ImportationParams | None = None) -> None:
+    def __init__(self, model, params: ImportationParams | None = None) -> None:
         """
         Initialize an Infect_Random_Agents instance.
 
@@ -124,7 +123,6 @@ class InfectAgentsInPatchProcess:
             period: The number of ticks between each infection event.
             count: The number of agents to infect at each event.
             start (int, optional): The tick at which to start the infection events.
-            verbose (bool, optional): If True, enables verbose output. Defaults to False.
 
         Attributes:
 

--- a/src/laser/measles/abm/components/process_importation.py
+++ b/src/laser/measles/abm/components/process_importation.py
@@ -47,9 +47,12 @@ class InfectRandomAgentsProcess:
         Args:
 
             model: The model object that contains the population.
-            period: The number of ticks between each infection event.
-            count: The number of agents to infect at each event.
-            start (int, optional): The tick at which to start the infection events.
+            params: Optional importation configuration. If provided, this should be an
+                ``ImportationParams`` instance whose ``importation_period``,
+                ``importation_count``, and ``importation_start`` fields are used to
+                initialize this process's ``period``, ``count``, and ``start``
+                attributes (and ``importation_end`` maps to ``end``). If ``None``,
+                the values are loaded from ``model.params`` for backward compatibility.
 
         Attributes:
 

--- a/src/laser/measles/abm/components/process_importation.py
+++ b/src/laser/measles/abm/components/process_importation.py
@@ -1,18 +1,12 @@
 """
-This module defines Importation classes, which provide methods to import cases into a population during simulation.
+Importation components: periodically introduce new infections into a population during simulation.
 
 Classes:
-    Infect_Random_Agents: A class to periodically infect a random subset of agents in the population
+    ImportationParams: Pydantic schema for configuring importation cadence, count, time window, and patch targets.
+    InfectRandomAgentsProcess: Periodically infects a random subset of agents drawn from anywhere in the population.
+    InfectAgentsInPatchProcess: Periodically infects a fixed number of agents in each patch listed in ``importation_patchlist`` (defaults to all patches).
 
-Functions:
-    Infect_Random_Agents.__init__(self, model, period, count, start) -> None:
-        Initializes the Infect_Random_Agents class with a given model, period, count, and start time.
-
-    Infect_Random_Agents.__call__(self, model, tick) -> None:
-        Checks whether it is time to infect a random subset of agents and infects them if necessary.
-
-    Infect_Random_Agents.plot(self, fig: Figure = None):
-        Nothing yet.
+Both process classes share the same ``__init__(model, params: ImportationParams | None = None)`` signature; if ``params`` is omitted, values are read from ``model.params`` for backward compatibility.
 """
 
 import numpy as np
@@ -42,10 +36,9 @@ class InfectRandomAgentsProcess:
 
     def __init__(self, model, params: ImportationParams | None = None) -> None:
         """
-        Initialize an Infect_Random_Agents instance.
+        Initialize an InfectRandomAgentsProcess instance.
 
         Args:
-
             model: The model object that contains the population.
             params: Optional importation configuration. If provided, this should be an
                 ``ImportationParams`` instance whose ``importation_period``,
@@ -118,10 +111,9 @@ class InfectAgentsInPatchProcess:
 
     def __init__(self, model, params: ImportationParams | None = None) -> None:
         """
-        Initialize an Infect_Random_Agents instance.
+        Initialize an InfectAgentsInPatchProcess instance.
 
         Args:
-
             model: The model object that contains the population.
             params: Optional importation configuration. When provided, this should
                 be an ``ImportationParams`` instance whose

--- a/src/laser/measles/abm/components/process_importation.py
+++ b/src/laser/measles/abm/components/process_importation.py
@@ -120,9 +120,14 @@ class InfectAgentsInPatchProcess:
         Args:
 
             model: The model object that contains the population.
-            period: The number of ticks between each infection event.
-            count: The number of agents to infect at each event.
-            start (int, optional): The tick at which to start the infection events.
+            params: Optional importation configuration. When provided, this should
+                be an ``ImportationParams`` instance whose
+                ``importation_period``, ``importation_count``,
+                ``importation_start``, ``importation_end``, and
+                ``importation_patchlist`` fields control the timing, number of
+                imported infections, start/end ticks, and patches targeted by
+                this process. If ``None``, these values are populated from
+                ``model.params`` for backward compatibility.
 
         Attributes:
 

--- a/src/laser/measles/abm/components/process_importation_pressure.py
+++ b/src/laser/measles/abm/components/process_importation_pressure.py
@@ -162,8 +162,6 @@ class ImportationPressureProcess(BasePhase):
     ----------
     model : object
         The simulation model containing nodes, states, and parameters
-    verbose : bool, default=False
-        Whether to print verbose output during simulation
     params : Optional[ImportationPressureParams], default=None
         Component-specific parameters. If None, will use default parameters
 
@@ -174,8 +172,8 @@ class ImportationPressureProcess(BasePhase):
     - All state counts are ensured to be non-negative
     """
 
-    def __init__(self, model, verbose: bool = False, params: ImportationPressureParams | None = None) -> None:
-        super().__init__(model, verbose)
+    def __init__(self, model, params: ImportationPressureParams | None = None) -> None:
+        super().__init__(model)
         self.params = params or ImportationPressureParams()
         self.patch_rates_per_year_per_1k: np.ndarray | None = None
 

--- a/src/laser/measles/abm/components/process_infection.py
+++ b/src/laser/measles/abm/components/process_infection.py
@@ -86,22 +86,21 @@ class InfectionProcess(BaseInfectionProcess):
     but for agent-based modeling.
     """
 
-    def __init__(self, model: ABMModel, verbose: bool = False, params: InfectionParams | None = None) -> None:
+    def __init__(self, model: ABMModel, params: InfectionParams | None = None) -> None:
         """
         Initialize the combined infection process.
 
         Args:
             model: The model object that contains the patches and parameters.
-            verbose (bool, optional): If True, enables verbose output. Defaults to False.
             params: Combined parameters for both transmission and disease processes.
         """
-        super().__init__(model, verbose)
+        super().__init__(model)
 
         self.params = params if params is not None else InfectionParams()
 
         # Initialize sub-components
-        self.transmission = TransmissionProcess(model, verbose, self.params.transmission_params)
-        self.disease = DiseaseProcess(model, verbose, self.params.disease_params)
+        self.transmission = TransmissionProcess(model, self.params.transmission_params)
+        self.disease = DiseaseProcess(model, self.params.disease_params)
 
     def __call__(self, model, tick: int) -> None:
         """

--- a/src/laser/measles/abm/components/process_infection_seeding.py
+++ b/src/laser/measles/abm/components/process_infection_seeding.py
@@ -65,7 +65,6 @@ class InfectionSeedingProcess(BaseComponent):
 
     Args:
         model: The compartmental model instance.
-        verbose: Whether to print verbose output during initialization.
         params: Component-specific parameters. If None, uses default parameters.
 
     Example:
@@ -90,8 +89,8 @@ class InfectionSeedingProcess(BaseComponent):
             )
     """
 
-    def __init__(self, model: BaseLaserModel, verbose: bool = False, params: InfectionSeedingParams | None = None) -> None:
-        super().__init__(model, verbose)
+    def __init__(self, model: BaseLaserModel, params: InfectionSeedingParams | None = None) -> None:
+        super().__init__(model)
         self.params = params or InfectionSeedingParams()
         self._validate_params()
 

--- a/src/laser/measles/abm/components/process_initialize_equilibrium_states.py
+++ b/src/laser/measles/abm/components/process_initialize_equilibrium_states.py
@@ -92,7 +92,7 @@ class InitializeEquilibriumStatesProcess(BaseInitializeEquilibriumStatesProcess)
 
             current_index += patch_pop
 
-        if model.params.verbose:
+        if self.verbose:
             total_s = np.sum(people.state == model.params.states.index("S"))
             total_r = np.sum(people.state == model.params.states.index("R"))
             print(f"Initialized {total_s} susceptible and {total_r} recovered agents")

--- a/src/laser/measles/abm/components/process_no_births.py
+++ b/src/laser/measles/abm/components/process_no_births.py
@@ -31,10 +31,9 @@ class NoBirthsProcess(BaseVitalDynamicsProcess):
     def __init__(
         self,
         model: BaseLaserModel,
-        verbose: bool = False,
         params: NoBirthsParams | None = None,
     ) -> None:
-        super().__init__(model, verbose)
+        super().__init__(model)
 
         if params is None:
             params = NoBirthsParams()

--- a/src/laser/measles/abm/components/process_sia_calendar.py
+++ b/src/laser/measles/abm/components/process_sia_calendar.py
@@ -37,8 +37,6 @@ class SIACalendarProcess(BasePhase):
     ----------
     model : ABMModel
         The ABM simulation model containing agents, patches, and parameters
-    verbose : bool, default=False
-        Whether to print verbose output during simulation
     params : Optional[SIACalendarParams], default=None
         Component-specific parameters. If None, will use default parameters
 
@@ -52,8 +50,8 @@ class SIACalendarProcess(BasePhase):
     - Each SIA is implemented exactly once
     """
 
-    def __init__(self, model: ABMModel, verbose: bool = False, params: SIACalendarParams | None = None) -> None:
-        super().__init__(model, verbose)
+    def __init__(self, model: ABMModel, params: SIACalendarParams | None = None) -> None:
+        super().__init__(model)
         if params is None:
             raise ValueError("SIACalendarParams must be provided")
         self.params = params

--- a/src/laser/measles/abm/components/process_transmission.py
+++ b/src/laser/measles/abm/components/process_transmission.py
@@ -131,14 +131,13 @@ class TransmissionProcess(BasePhase):
     A component to model the transmission of disease in a population.
     """
 
-    def __init__(self, model, verbose: bool = False, params: TransmissionParams | None = None) -> None:
+    def __init__(self, model, params: TransmissionParams | None = None) -> None:
         """
         Initializes the transmission object.
 
         Args:
 
             model: The model object that contains the patches and parameters.
-            verbose (bool, optional): If True, enables verbose output. Defaults to False.
 
         Attributes:
 
@@ -151,7 +150,7 @@ class TransmissionProcess(BasePhase):
             - 'incidence': A vector property with length equal to the number of ticks, dtype is uint32.
         """
 
-        super().__init__(model, verbose)
+        super().__init__(model)
 
         self.params = params if params is not None else TransmissionParams()
 

--- a/src/laser/measles/abm/components/process_vital_dynamics.py
+++ b/src/laser/measles/abm/components/process_vital_dynamics.py
@@ -25,9 +25,9 @@ class VitalDynamicsProcess(BaseVitalDynamicsProcess):
     Process for simulating vital dynamics in the ABM model with MCV1 and constant birth and mortality rates (not age-structured).
     """
 
-    def __init__(self, model, verbose: bool = False, params: VitalDynamicsParams | None = None) -> None:
+    def __init__(self, model, params: VitalDynamicsParams | None = None) -> None:
         params_: VitalDynamicsParams = params or VitalDynamicsParams()
-        super().__init__(model, verbose=verbose, params=params_)
+        super().__init__(model, params=params_)
 
         date_of_birth_dtype = np.int32
         self.null_value = np.iinfo(date_of_birth_dtype).max

--- a/src/laser/measles/abm/components/process_wpp_vital_dynamics.py
+++ b/src/laser/measles/abm/components/process_wpp_vital_dynamics.py
@@ -23,8 +23,8 @@ class WPPVitalDynamicsParams(BaseModel):
 
 
 class WPPVitalDynamicsProcess(BasePhase):
-    def __init__(self, model, verbose: bool = False, params: WPPVitalDynamicsParams | None = None) -> None:
-        super().__init__(model, verbose)
+    def __init__(self, model, params: WPPVitalDynamicsParams | None = None) -> None:
+        super().__init__(model)
         if params is None:
             params = WPPVitalDynamicsParams()
         self.params = params

--- a/src/laser/measles/abm/components/tracker_age_pyramid.py
+++ b/src/laser/measles/abm/components/tracker_age_pyramid.py
@@ -34,8 +34,8 @@ class AgePyramidTrackerParams(BaseModel):
 class AgePyramidTracker(BasePhase):
     """Track the age distribution of the population."""
 
-    def __init__(self, model, verbose: bool = False, params: AgePyramidTrackerParams | None = None):
-        super().__init__(model, verbose)
+    def __init__(self, model, params: AgePyramidTrackerParams | None = None):
+        super().__init__(model)
         self.params = params or AgePyramidTrackerParams()
         self.age_pyramid = {}
         self.last_call = model.current_date

--- a/src/laser/measles/base.py
+++ b/src/laser/measles/base.py
@@ -339,7 +339,7 @@ class BaseLaserModel(ABC):
         self.instances = []
         self.phases = []
         for component in components:
-            instance = component(self, verbose=getattr(self.params, "verbose", False))
+            instance = component(self)
             self.instances.append(instance)
             if "__call__" in dir(instance):
                 self.phases.append(instance)
@@ -357,7 +357,7 @@ class BaseLaserModel(ABC):
             component: A component class to be initialized and integrated into the model.
         """
         self._components.append(component)
-        instance = component(self, verbose=getattr(self.params, "verbose", False))
+        instance = component(self)
         self.instances.append(instance)
         if "__call__" in dir(instance):
             self.phases.append(instance)
@@ -371,7 +371,7 @@ class BaseLaserModel(ABC):
             component: A component class to be initialized and integrated into the model.
         """
         self._components.insert(0, component)
-        instance = component(self, verbose=getattr(self.params, "verbose", False))
+        instance = component(self)
         self.instances.insert(0, instance)
         if "__call__" in dir(instance):
             self.phases.insert(0, instance)
@@ -652,20 +652,27 @@ class BaseComponent:
 
     ModelType = TypeVar("ModelType")
 
-    def __init__(self, model: BaseLaserModel, verbose: bool = False, params: None = None) -> None:  # TODO: add ParamsType
+    def __init__(self, model: BaseLaserModel, params: None = None) -> None:  # TODO: add ParamsType
         """
         Initialize the component.
 
         Args:
             model: The model instance this component belongs to.
-            verbose: Whether to enable verbose output. Defaults to False.
         """
         self.model = model
-        self.verbose = verbose
         self.initialized = False
         self.params = params
         if not hasattr(self, "name"):
             self.name = self.__class__.__name__
+
+    @property
+    def verbose(self) -> bool:
+        # Single source of truth: model.params.verbose. Property (not stored attr)
+        # so toggling params.verbose at runtime is immediately visible to the component.
+        params = getattr(self.model, "params", None)
+        if params is None:
+            return False
+        return getattr(params, "verbose", False)
 
     def __str__(self) -> str:
         """

--- a/src/laser/measles/base.py
+++ b/src/laser/measles/base.py
@@ -652,7 +652,7 @@ class BaseComponent:
 
     ModelType = TypeVar("ModelType")
 
-    def __init__(self, model: BaseLaserModel, params: None = None) -> None:  # TODO: add ParamsType
+    def __init__(self, model: BaseLaserModel, params: Any | None = None) -> None:  # TODO: add ParamsType
         """
         Initialize the component.
 

--- a/src/laser/measles/biweekly/components/process_constant_pop.py
+++ b/src/laser/measles/biweekly/components/process_constant_pop.py
@@ -18,7 +18,6 @@ class ConstantPopProcess(BaseConstantPopProcess):
     Attributes:
 
         model: The model instance containing population and parameters.
-        verbose (bool): Flag to enable verbose output. Default is False.
         initializers (list): List of initializers to be called on birth events.
         metrics (DataFrame): DataFrame to holding timing metrics for initializers.
     """

--- a/src/laser/measles/biweekly/components/process_importation_pressure.py
+++ b/src/laser/measles/biweekly/components/process_importation_pressure.py
@@ -156,8 +156,6 @@ class ImportationPressureProcess(BasePhase):
     ----------
     model : object
         The simulation model containing nodes, states, and parameters
-    verbose : bool, default=False
-        Whether to print verbose output during simulation
     params : Optional[ImportationPressureParams], default=None
         Component-specific parameters. If None, will use default parameters
 
@@ -168,8 +166,8 @@ class ImportationPressureProcess(BasePhase):
     - All state counts are ensured to be non-negative
     """
 
-    def __init__(self, model, verbose: bool = False, params: ImportationPressureParams | None = None) -> None:
-        super().__init__(model, verbose)
+    def __init__(self, model, params: ImportationPressureParams | None = None) -> None:
+        super().__init__(model)
         self.params = params or ImportationPressureParams()
         self.patch_rates_per_year_per_1k: np.ndarray | None = None
 

--- a/src/laser/measles/biweekly/components/process_infection.py
+++ b/src/laser/measles/biweekly/components/process_infection.py
@@ -53,8 +53,6 @@ class InfectionProcess(BaseInfectionProcess):
     ----------
     model : object
         The simulation model containing population states and parameters
-    verbose : bool, default=False
-        Whether to print detailed information during execution
     params : InfectionParams | None, default=None
         Component-specific parameters. If None, will use default parameters
 
@@ -64,8 +62,8 @@ class InfectionProcess(BaseInfectionProcess):
     transmission rate that varies sinusoidally over time.
     """
 
-    def __init__(self, model: BaseLaserModel, verbose: bool = False, params: InfectionParams | None = None) -> None:
-        super().__init__(model, verbose)
+    def __init__(self, model: BaseLaserModel, params: InfectionParams | None = None) -> None:
+        super().__init__(model)
         if params is None:
             params = InfectionParams()
         self.params = params

--- a/src/laser/measles/biweekly/components/process_sia_calendar.py
+++ b/src/laser/measles/biweekly/components/process_sia_calendar.py
@@ -37,8 +37,6 @@ class SIACalendarProcess(BasePhase):
     ----------
     model : object
         The simulation model containing nodes, states, and parameters
-    verbose : bool, default=False
-        Whether to print verbose output during simulation
     params : Optional[SIACalendarParams], default=None
         Component-specific parameters. If None, will use default parameters
 
@@ -51,8 +49,8 @@ class SIACalendarProcess(BasePhase):
     - Each SIA is implemented exactly once
     """
 
-    def __init__(self, model, verbose: bool = False, params: SIACalendarParams | None = None) -> None:
-        super().__init__(model, verbose)
+    def __init__(self, model, params: SIACalendarParams | None = None) -> None:
+        super().__init__(model)
         if params is None:
             raise ValueError("SIACalendarParams must be provided")
         self.params = params

--- a/src/laser/measles/biweekly/components/tracker_fadeout.py
+++ b/src/laser/measles/biweekly/components/tracker_fadeout.py
@@ -5,8 +5,8 @@ from laser.measles.components import BaseFadeOutTrackerParams
 class FadeOutTracker(BaseFadeOutTracker):
     """A component that tracks the number of nodes experiencing fade-outs over time."""
 
-    def __init__(self, model, verbose: bool = False) -> None:
-        super().__init__(model, verbose)
+    def __init__(self, model) -> None:
+        super().__init__(model)
 
 
 class FadeOutTrackerParams(BaseFadeOutTrackerParams):

--- a/src/laser/measles/compartmental/components/process_constant_pop.py
+++ b/src/laser/measles/compartmental/components/process_constant_pop.py
@@ -18,7 +18,6 @@ class ConstantPopProcess(BaseConstantPopProcess):
     Attributes:
 
         model: The model instance containing population and parameters.
-        verbose (bool): Flag to enable verbose output. Default is False.
         initializers (list): List of initializers to be called on birth events.
         metrics (DataFrame): DataFrame to holding timing metrics for initializers.
     """

--- a/src/laser/measles/compartmental/components/process_importation_pressure.py
+++ b/src/laser/measles/compartmental/components/process_importation_pressure.py
@@ -162,8 +162,6 @@ class ImportationPressureProcess(BasePhase):
     ----------
     model : object
         The simulation model containing nodes, states, and parameters
-    verbose : bool, default=False
-        Whether to print verbose output during simulation
     params : Optional[ImportationPressureParams], default=None
         Component-specific parameters. If None, will use default parameters
 
@@ -174,8 +172,8 @@ class ImportationPressureProcess(BasePhase):
     - All state counts are ensured to be non-negative
     """
 
-    def __init__(self, model, verbose: bool = False, params: ImportationPressureParams | None = None) -> None:
-        super().__init__(model, verbose)
+    def __init__(self, model, params: ImportationPressureParams | None = None) -> None:
+        super().__init__(model)
         self.params = params or ImportationPressureParams()
         self.patch_rates_per_year_per_1k: np.ndarray | None = None
 

--- a/src/laser/measles/compartmental/components/process_infection.py
+++ b/src/laser/measles/compartmental/components/process_infection.py
@@ -100,8 +100,6 @@ class InfectionProcess(BaseInfectionProcess):
     ----------
     model : object
         The simulation model containing population states and parameters
-    verbose : bool, default=False
-        Whether to print detailed information during execution
     params : InfectionParams | None, default=None
         Component-specific parameters. If None, will use default parameters
 
@@ -111,8 +109,8 @@ class InfectionProcess(BaseInfectionProcess):
     sinusoidally over time with a period of 365 days.
     """
 
-    def __init__(self, model: BaseLaserModel, params: InfectionParams | None = None, verbose: bool = False) -> None:
-        super().__init__(model, verbose)
+    def __init__(self, model: BaseLaserModel, params: InfectionParams | None = None) -> None:
+        super().__init__(model)
 
         self.params = params if params is not None else InfectionParams()
 

--- a/src/laser/measles/compartmental/components/process_sia_calendar.py
+++ b/src/laser/measles/compartmental/components/process_sia_calendar.py
@@ -43,8 +43,6 @@ class SIACalendarProcess(BasePhase):
     ----------
     model : object
         The simulation model containing nodes, states, and parameters
-    verbose : bool, default=False
-        Whether to print verbose output during simulation
     params : Optional[SIACalendarParams], default=None
         Component-specific parameters. If None, will use default parameters
 
@@ -57,8 +55,8 @@ class SIACalendarProcess(BasePhase):
     - Each SIA is implemented exactly once
     """
 
-    def __init__(self, model: CompartmentalModel, verbose: bool = False, params: SIACalendarParams | None = None) -> None:
-        super().__init__(model, verbose)
+    def __init__(self, model: CompartmentalModel, params: SIACalendarParams | None = None) -> None:
+        super().__init__(model)
         if params is None:
             raise ValueError("SIACalendarParams must be provided")
         self.params = params

--- a/src/laser/measles/compartmental/components/process_vital_dynamics.py
+++ b/src/laser/measles/compartmental/components/process_vital_dynamics.py
@@ -19,8 +19,8 @@ class VitalDynamicsProcess(BaseVitalDynamicsProcess):
     Phase for simulating the vital dynamics in the model with MCV1.
     """
 
-    def __init__(self, model, verbose: bool = False, params: VitalDynamicsParams | None = None) -> None:
-        super().__init__(model, verbose, params)
+    def __init__(self, model, params: VitalDynamicsParams | None = None) -> None:
+        super().__init__(model, params)
         model.patches.add_scalar_property("births", dtype=np.uint32)
         model.patches.add_scalar_property("deaths", dtype=np.uint32)
 

--- a/src/laser/measles/components/base_case_surveillance.py
+++ b/src/laser/measles/components/base_case_surveillance.py
@@ -45,12 +45,11 @@ class BaseCaseSurveillanceTracker(BasePhase):
 
     Args:
         model: The simulation model containing nodes, states, and parameters.
-        verbose: Whether to print verbose output during simulation. Defaults to False.
         params: Component-specific parameters. If None, will use default parameters.
     """
 
-    def __init__(self, model, verbose: bool = False, params: BaseCaseSurveillanceParams | None = None) -> None:
-        super().__init__(model, verbose)
+    def __init__(self, model, params: BaseCaseSurveillanceParams | None = None) -> None:
+        super().__init__(model)
         self.params = params or BaseCaseSurveillanceParams()
         self._validate_params()
 

--- a/src/laser/measles/components/base_constant_pop.py
+++ b/src/laser/measles/components/base_constant_pop.py
@@ -28,24 +28,22 @@ class BaseConstantPopProcess(BaseVitalDynamicsProcess):
     Attributes:
 
         model: The model instance containing population and parameters.
-        verbose (bool): Flag to enable verbose output. Default is False.
         initializers (list): List of initializers to be called on birth events.
         metrics (DataFrame): DataFrame to holding timing metrics for initializers.
     """
 
-    def __init__(self, model: BaseLaserModel, verbose: bool = False, params: BaseConstantPopParams | None = None):
+    def __init__(self, model: BaseLaserModel, params: BaseConstantPopParams | None = None):
         """
         Initialize the Births component.
 
         Parameters:
 
             model (object): The model object which must have a `population` attribute.
-            verbose (bool, optional): If True, enables verbose output. Defaults to False.
             params (BirthsParams, optional): Component parameters. If None, uses model.params.
 
         """
 
-        super().__init__(model, verbose)
+        super().__init__(model)
 
         self.params = params if params is not None else BaseConstantPopParams()
 

--- a/src/laser/measles/components/base_importation.py
+++ b/src/laser/measles/components/base_importation.py
@@ -26,8 +26,8 @@ class BaseImportationParams(BaseModel):
 class BaseImportation(BasePhase, ABC):
     """Abstract base class for importation components."""
 
-    def __init__(self, model, verbose: bool = False, params: BaseImportationParams | None = None):
-        super().__init__(model, verbose)
+    def __init__(self, model, params: BaseImportationParams | None = None):
+        super().__init__(model)
         self.params = params if params is not None else BaseImportationParams()
 
     @abstractmethod

--- a/src/laser/measles/components/base_infection_seeding.py
+++ b/src/laser/measles/components/base_infection_seeding.py
@@ -66,8 +66,6 @@ class BaseInfectionSeedingProcess(BaseComponent):
     ----------
     model : BaseLaserModel
         The compartmental model instance
-    verbose : bool, default=False
-        Whether to print verbose output during initialization
     params : Optional[InfectionSeedingParams], default=None
         Component-specific parameters. If None, will use default parameters
 
@@ -92,8 +90,8 @@ class BaseInfectionSeedingProcess(BaseComponent):
     )
     """
 
-    def __init__(self, model: BaseLaserModel, verbose: bool = False, params: BaseInfectionSeedingParams | None = None) -> None:
-        super().__init__(model, verbose)
+    def __init__(self, model: BaseLaserModel, params: BaseInfectionSeedingParams | None = None) -> None:
+        super().__init__(model)
         self.params = params or BaseInfectionSeedingParams()
         self._validate_params()
 

--- a/src/laser/measles/components/base_initialize_equilibrium_states.py
+++ b/src/laser/measles/components/base_initialize_equilibrium_states.py
@@ -23,8 +23,8 @@ class BaseInitializeEquilibriumStatesProcess(BasePhase):
     Initialize S, R states of the population in each of the model states by rough equilibrium of R0.
     """
 
-    def __init__(self, model: BaseLaserModel, verbose: bool = False, params: BaseInitializeEquilibriumStatesParams | None = None):
-        super().__init__(model, verbose)
+    def __init__(self, model: BaseLaserModel, params: BaseInitializeEquilibriumStatesParams | None = None):
+        super().__init__(model)
         self.params = params or BaseInitializeEquilibriumStatesParams()
 
     def _initialize(self, model: BaseLaserModel):

--- a/src/laser/measles/components/base_tracker.py
+++ b/src/laser/measles/components/base_tracker.py
@@ -23,8 +23,8 @@ class BaseTrackerParams(BaseModel):
 class BaseTracker(BaseComponent, ABC):
     """Abstract base class for tracker components."""
 
-    def __init__(self, model, verbose: bool = False, params: BaseTrackerParams | None = None):
-        super().__init__(model, verbose)
+    def __init__(self, model, params: BaseTrackerParams | None = None):
+        super().__init__(model)
         self.params = params if params is not None else BaseTrackerParams()
         self.data = {}  # Storage for tracked data
 

--- a/src/laser/measles/components/base_tracker_fadeout.py
+++ b/src/laser/measles/components/base_tracker_fadeout.py
@@ -31,11 +31,10 @@ class BaseFadeOutTracker(BasePhase):
 
     Args:
         model: The simulation model instance.
-        verbose (bool, optional): Whether to enable verbose logging. Defaults to False.
     """
 
-    def __init__(self, model, verbose: bool = False) -> None:
-        super().__init__(model, verbose)
+    def __init__(self, model) -> None:
+        super().__init__(model)
         self.fade_out_tracker = np.zeros(model.params.num_ticks)
 
     def __call__(self, model, tick: int) -> None:

--- a/src/laser/measles/components/base_tracker_population.py
+++ b/src/laser/measles/components/base_tracker_population.py
@@ -14,8 +14,8 @@ class BasePopulationTracker(BasePhase):
     Tracks the population size of each patch at each time tick.
     """
 
-    def __init__(self, model: BaseLaserModel, verbose: bool = False, params: BasePopulationTrackerParams | None = None) -> None:
-        super().__init__(model, verbose)
+    def __init__(self, model: BaseLaserModel, params: BasePopulationTrackerParams | None = None) -> None:
+        super().__init__(model)
         self.params = params or BasePopulationTrackerParams()
         self.population_tracker = np.zeros((model.patches.count, model.params.num_ticks), dtype=model.patches.states.dtype)
 

--- a/src/laser/measles/components/base_tracker_state.py
+++ b/src/laser/measles/components/base_tracker_state.py
@@ -59,12 +59,11 @@ class BaseStateTracker(BasePhase):
 
     Args:
         model: The simulation model containing nodes, states, and parameters.
-        verbose: Whether to print verbose output during simulation. Defaults to False.
         params: Component-specific parameters. If None, will use default parameters.
     """
 
-    def __init__(self, model, verbose: bool = False, params: BaseStateTrackerParams | None = None) -> None:
-        super().__init__(model, verbose)
+    def __init__(self, model, params: BaseStateTrackerParams | None = None) -> None:
+        super().__init__(model)
         self.name = "StateTracker"
         self.params = params or BaseStateTrackerParams()
         self._validate_params()

--- a/src/laser/measles/components/base_transmission.py
+++ b/src/laser/measles/components/base_transmission.py
@@ -45,15 +45,14 @@ class BaseTransmission(BasePhase, ABC):
     mathematical approach (agent-based, compartmental, etc.).
     """
 
-    def __init__(self, model, verbose: bool = False, params: BaseTransmissionParams | None = None):
+    def __init__(self, model, params: BaseTransmissionParams | None = None):
         """Initialize the transmission component.
 
         Args:
             model: The model instance this component belongs to
-            verbose: Whether to enable verbose logging
             params: Component parameters (uses defaults if None)
         """
-        super().__init__(model, verbose)
+        super().__init__(model)
         self.params = params if params is not None else BaseTransmissionParams()
 
         # Set random seed if specified

--- a/src/laser/measles/components/base_vital_dynamics.py
+++ b/src/laser/measles/components/base_vital_dynamics.py
@@ -52,8 +52,6 @@ class BaseVitalDynamicsProcess(BasePhase, ABC):
     ----------
     model : object
         The simulation model containing nodes, states, and parameters
-    verbose : bool, default=False
-        Whether to print verbose output during simulation
     params : VitalDynamicsParams | None, default=None
         Component-specific parameters. If None, will use default parameters
 
@@ -64,8 +62,8 @@ class BaseVitalDynamicsProcess(BasePhase, ABC):
       time before routine immunization significantly shifts population-level immunity
     """
 
-    def __init__(self, model, verbose: bool = False, params: BaseVitalDynamicsParams | None = None) -> None:
-        super().__init__(model, verbose)
+    def __init__(self, model, params: BaseVitalDynamicsParams | None = None) -> None:
+        super().__init__(model)
         if params is None:
             params = BaseVitalDynamicsParams()
         self.params = params

--- a/src/laser/measles/components/utils.py
+++ b/src/laser/measles/components/utils.py
@@ -46,8 +46,8 @@ def component(cls: type[T] | None = None, **default_params):  # noqa: UP047
 
     >>> @component
     ... class MyComponent(BaseComponent):
-    ...     def __init__(self, model, verbose=False, param1=1, param2=2):
-    ...         super().__init__(model, verbose)
+    ...     def __init__(self, model, param1=1, param2=2):
+    ...         super().__init__(model)
     ...         self.param1 = param1
     ...         self.param2 = param2
 
@@ -55,8 +55,8 @@ def component(cls: type[T] | None = None, **default_params):  # noqa: UP047
 
     >>> @component(param1=10, param2=20)
     ... class MyComponent(BaseComponent):
-    ...     def __init__(self, model, verbose=False, param1=1, param2=2):
-    ...         super().__init__(model, verbose)
+    ...     def __init__(self, model, param1=1, param2=2):
+    ...         super().__init__(model)
     ...         self.param1 = param1
     ...         self.param2 = param2
 
@@ -127,8 +127,8 @@ def create_component(component_class: type[T], params: type[B] | None = None) ->
             else:
                 self.params = None
 
-        def __call__(self, model: Any, verbose: bool = False) -> T:
-            return self.component_class(model, params=self.params, verbose=verbose)
+        def __call__(self, model: Any) -> T:
+            return self.component_class(model, params=self.params)
 
         def __str__(self) -> str:
             return f"<{self.component_class.__name__} factory>"

--- a/src/laser/measles/components/utils.py
+++ b/src/laser/measles/components/utils.py
@@ -92,7 +92,7 @@ def component(cls: type[T] | None = None, **default_params):  # noqa: UP047
     return decorator
 
 
-def create_component(component_class: type[T], params: type[B] | None = None) -> Callable[[Any, Any], T]:  # noqa: UP047
+def create_component(component_class: type[T], params: type[B] | None = None) -> Callable[[Any], T]:  # noqa: UP047
     """
     Helper function to create a component instance with parameters.
 
@@ -103,13 +103,14 @@ def create_component(component_class: type[T], params: type[B] | None = None) ->
     ----------
     component_class : Type[BaseComponent]
         The component class to instantiate
-    **kwargs
-        Parameters to pass to the component constructor
+    params : BaseModel, optional
+        Parameter object to pass to the component constructor as ``params=...``.
 
     Returns
     -------
-    Callable[[Any, Any], BaseComponent]
-        A function that creates the component instance when called by the model
+    Callable[[Any], BaseComponent]
+        A single-argument factory: when called by the model with the model
+        instance, it returns ``component_class(model, params=params)``.
 
     Examples
     --------

--- a/tests/unit/test_base_component.py
+++ b/tests/unit/test_base_component.py
@@ -50,15 +50,6 @@ class TestBaseComponent:
         assert component.verbose is False
         assert component.initialized is False  # Should be False initially
 
-    def test_initialization_with_verbose(self):
-        """Test BaseComponent initialization with verbose=True."""
-        model = MockModel()
-        component = MockComponentWithoutDocstring(model, verbose=True)
-
-        assert component.model is model
-        assert component.verbose is True
-        assert component.initialized is False  # Should be False initially
-
     def test_call_method_exists(self):
         """Test that __call__ method exists and can be called."""
         model = MockModel()

--- a/tests/unit/test_progress_bar.py
+++ b/tests/unit/test_progress_bar.py
@@ -29,9 +29,8 @@ def test_progress_bar(measles_module):
 
     # Add a simple component that does nothing
     class DummyComponent(BaseComponent):
-        def __init__(self, model, verbose=False):
+        def __init__(self, model):
             self.model = model
-            self.verbose = verbose
             self.initialized = False
 
         def _initialize(self, model):

--- a/tests/unit/test_sia_calendar.py
+++ b/tests/unit/test_sia_calendar.py
@@ -325,11 +325,12 @@ class TestSIACalendarProcess:
         """Test verbose output."""
         module = importlib.import_module(measles_module)
         model = create_model(mock_scenario, module)
+        model.params.verbose = True
 
         # Create verbose component
         sia_schedule = create_sia_schedule(measles_module)
         sia_params = module.components.SIACalendarParams(sia_schedule=sia_schedule, sia_efficacy=1.0, aggregation_level=2)
-        module.components.SIACalendarProcess(model, verbose=True, params=sia_params)
+        module.components.SIACalendarProcess(model, params=sia_params)
 
         # Check initialization message
         captured = capsys.readouterr()

--- a/tests/unit/test_verbose_standardization.py
+++ b/tests/unit/test_verbose_standardization.py
@@ -1,0 +1,89 @@
+"""
+Tests for the standardization of the verbose flag on model.params.
+
+The contract:
+- BaseComponent.verbose is a dynamic property mirroring self.model.params.verbose.
+- Components no longer accept a verbose constructor kwarg; passing one raises TypeError.
+- Toggling model.params.verbose is immediately observable by every component instance.
+"""
+
+import importlib
+
+import pytest
+
+import laser.measles as lm
+from laser.measles import MEASLES_MODULES
+from laser.measles.base import BaseComponent
+
+
+class _TrivialComponent(BaseComponent):
+    def __call__(self, model, tick):
+        pass
+
+    def _initialize(self, model):
+        pass
+
+
+def _make_model(measles_module, verbose):
+    MeaslesModel = importlib.import_module(measles_module)
+    scenario = MeaslesModel.BaseScenario(lm.scenarios.synthetic.single_patch_scenario())
+    return MeaslesModel.Model(scenario, MeaslesModel.Params(num_ticks=0, verbose=verbose))
+
+
+@pytest.mark.parametrize("measles_module", MEASLES_MODULES)
+def test_verbose_property_reads_model_params(measles_module):
+    model = _make_model(measles_module, verbose=True)
+    assert _TrivialComponent(model).verbose is True
+
+    model = _make_model(measles_module, verbose=False)
+    assert _TrivialComponent(model).verbose is False
+
+
+@pytest.mark.parametrize("measles_module", MEASLES_MODULES)
+def test_verbose_property_is_dynamic(measles_module):
+    """Mutating params.verbose after construction must be visible on the component.
+
+    This is the regression test for the original 'dropped verbose' bug pattern:
+    when verbose was a stored constructor arg, post-construction mutations were
+    invisible. With verbose as a property over model.params.verbose, they are.
+    """
+    model = _make_model(measles_module, verbose=False)
+    component = _TrivialComponent(model)
+    assert component.verbose is False
+
+    model.params.verbose = True
+    assert component.verbose is True
+
+
+def test_basecomponent_no_longer_accepts_verbose_kwarg():
+    class _MockModel:
+        pass
+
+    with pytest.raises(TypeError):
+        _TrivialComponent(_MockModel(), verbose=True)
+
+
+@pytest.mark.parametrize("measles_module", MEASLES_MODULES)
+def test_infection_seeding_emits_when_verbose_true(measles_module, capsys):
+    MeaslesModel = importlib.import_module(measles_module)
+    scenario = MeaslesModel.BaseScenario(lm.scenarios.synthetic.single_patch_scenario())
+    model = MeaslesModel.Model(scenario, MeaslesModel.Params(num_ticks=1, verbose=True, show_progress=False))
+    model.components = [
+        MeaslesModel.components.InfectionSeedingProcess,
+        MeaslesModel.components.InfectionProcess,
+    ]
+    model.run()
+    assert "Initializing infection seeding" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("measles_module", MEASLES_MODULES)
+def test_infection_seeding_silent_when_verbose_false(measles_module, capsys):
+    MeaslesModel = importlib.import_module(measles_module)
+    scenario = MeaslesModel.BaseScenario(lm.scenarios.synthetic.single_patch_scenario())
+    model = MeaslesModel.Model(scenario, MeaslesModel.Params(num_ticks=1, verbose=False, show_progress=False))
+    model.components = [
+        MeaslesModel.components.InfectionSeedingProcess,
+        MeaslesModel.components.InfectionProcess,
+    ]
+    model.run()
+    assert "Initializing infection seeding" not in capsys.readouterr().out


### PR DESCRIPTION
Fixes #9.

Components no longer accept a `verbose` constructor kwarg. `BaseComponent.verbose` is now a dynamic property that mirrors `model.params.verbose`, so toggling the flag at runtime is immediately visible to every component without kwarg threading. The previous design carried `verbose` through every component __init__ but only ever passed `params.verbose` at construction, so per-component verbosity was effectively unreachable.

Adds tests/unit/test_verbose_standardization.py with coverage across all three model variants for: dynamic property behavior, kwarg removal, and stdout-capture verification that `params.verbose` actually drives `if self.verbose:` code paths.