### PR TITLE
fix: coerce pop to Int64 so any integer width is accepted in scenarios

### DIFF
--- a/docs/concat_mkdocs.py
+++ b/docs/concat_mkdocs.py
@@ -103,11 +103,8 @@ def notebook_to_markdown(nb_path: Path) -> str:
                         # Skip lines that look like progress bars or pure decorative output
                         cleaned = re.sub(r"<[^>]+>", "", text).strip()
                         if cleaned:
-                            # Annotate Polars schema output that shows i64 for integer columns:
-                            # tutorial notebooks use untyped construction so schemas print i64,
-                            # but laser-measles requires Int32. Warn the LLM inline.
                             if re.search(r"┆\s*i64\s*┆|┆\s*i64\s*│|│\s*i64\s*┆|│\s*i64\s*│", cleaned):
-                                cleaned += "\n# NOTE: 'i64' shown above reflects untyped tutorial code. laser-measles requires Int32 for integer columns (pop, etc.) and str for id."
+                                cleaned += "\n# NOTE: 'i64' shown above is fine — laser-measles accepts any integer width for 'pop' and coerces it automatically."
                             parts.append(f"```\n{cleaned}\n```")
 
     md = "\n\n".join(parts)

--- a/docs/concat_mkdocs.py
+++ b/docs/concat_mkdocs.py
@@ -103,7 +103,7 @@ def notebook_to_markdown(nb_path: Path) -> str:
                         # Skip lines that look like progress bars or pure decorative output
                         cleaned = re.sub(r"<[^>]+>", "", text).strip()
                         if cleaned:
-                            if re.search(r"┆\s*i64\s*┆|┆\s*i64\s*│|│\s*i64\s*┆|│\s*i64\s*│", cleaned):
+                            if re.search(r"(?mi)^[^\n]*\bpop\b[^\n]*\bi64\b[^\n]*$", cleaned):
                                 cleaned += "\n# NOTE: 'i64' shown above is fine — laser-measles accepts any integer width for 'pop' and coerces it automatically."
                             parts.append(f"```\n{cleaned}\n```")
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1084,41 +1084,26 @@ BiweeklyParams(num_ticks=5 * 26)      # 130 biweekly ticks
 CompartmentalParams(num_ticks=5 * 365) # 1825 daily ticks
 ```
 
-### Scenario `id` must be a string; `pop` must be `Int32`
+### Scenario `id` must be a string; `pop` accepts any integer width
 
-Two dtype requirements that produce cryptic errors if violated:
+Two dtype requirements to be aware of:
 
 **`id` must be a string (`str` / `Utf8`), not an integer.**
 Python list comprehensions like `[0, 1, 2]` produce `Int64`, which fails
-schema validation. Use string patch IDs:
-
-Do not use integer lists for `id` — `[0, 1, 2]` produces `Int64` which
-fails schema validation. Always use string patch IDs:
+schema validation. Always use string patch IDs:
 
 ```python
 # CORRECT — string id
 scenario = pl.DataFrame({"id": ["patch_0", "patch_1", "patch_2"], ...})
 ```
 
-**`pop` (and all integer columns) must be `Int32`, not the default `Int64`.**
-Python integer lists and `np.array(...)` without a dtype both produce `Int64`:
-
-Do not use plain Python integer lists for `pop` — `[100_000, ...]`
-produces `Int64` which fails schema validation. Use `np.array(..., dtype=np.int32)`:
+**`pop` accepts any integer width** (`Int8`, `Int16`, `Int32`, `Int64`, unsigned variants).
+The library silently coerces `pop` to `Int64` at construction time, so plain Python
+integer lists work without any explicit cast:
 
 ```python
-import numpy as np, polars as pl
-
-# CORRECT — explicit Int32 via numpy
-scenario = pl.DataFrame({
-    "pop": np.array([100_000, 80_000, 60_000], dtype=np.int32),
-    ...
-})
-
-# ALSO CORRECT — build with defaults then cast
-scenario = pl.DataFrame({"pop": [100_000, 80_000, 60_000], ...}).with_columns(
-    pl.col("pop").cast(pl.Int32)
-)
+# CORRECT — plain Python list (produces Int64, accepted and coerced automatically)
+scenario = pl.DataFrame({"pop": [100_000, 80_000, 60_000], ...})
 ```
 
 The scenario helper functions (`single_patch_scenario`, `two_patch_scenario`, etc.)
@@ -1252,7 +1237,7 @@ pop       = initial_S            # approx total population per patch at t=0
 attack_rate = final_R / pop      # shape (n_patches,) — fraction ever infected
 
 # Pop must come from the scenario, NOT from tracker, for the denominator:
-pop_from_scenario = scenario["pop"].to_numpy()   # Int32 array, shape (n_patches,)
+pop_from_scenario = scenario["pop"].to_numpy()   # Int64 array, shape (n_patches,)
 attack_rate = final_R / pop_from_scenario.astype(float)
 ```
 
@@ -1403,7 +1388,7 @@ age_years  = age_ticks / 365.0
 Available people properties: `state`, `susceptibility`, `patch_id`,
 `active`, `date_of_birth`, `date_of_vaccination`.
 
-### Scenario `pop` column must be integer (`Int32`), not float
+### Scenario `pop` column must be integer, not float
 
 The scenario DataFrame validator requires `pop` to be an integer type.
 Passing a float column raises:
@@ -1412,7 +1397,8 @@ Passing a float column raises:
 ValueError: DataFrame validation error: Column 'pop' must be integer type
 ```
 
-Cast `pop` to `Int32` when building a scenario:
+Any integer width is accepted — plain Python integer lists (which Polars creates as `Int64`)
+work without any explicit cast:
 
 ```python
 import polars as pl
@@ -1421,11 +1407,9 @@ scenario = pl.DataFrame({
     "id":   ["patch_0", "patch_1"],
     "lat":  [0.0, 1.0],
     "lon":  [0.0, 1.0],
-    "pop":  pl.Series([100_000, 50_000], dtype=pl.Int32),
+    "pop":  [100_000, 50_000],   # Int64 by default — accepted automatically
     "mcv1": [0.8, 0.7],
 })
-# or cast after the fact:
-scenario = scenario.with_columns(pl.col("pop").cast(pl.Int32))
 ```
 
 ### Polars `with_column` (singular) was removed — use `with_columns`

--- a/src/laser/measles/base.py
+++ b/src/laser/measles/base.py
@@ -762,6 +762,10 @@ class BaseScenario(ABC):
         Args:
             df: The polars DataFrame containing scenario data.
         """
+        # Silently coerce integer pop to Int64 so users can write plain
+        # pl.DataFrame({"pop": [100_000]}) without explicit dtype casting.
+        if "pop" in df.columns and df["pop"].dtype != pl.Int64 and df["pop"].dtype.is_integer():
+            df = df.with_columns(pl.col("pop").cast(pl.Int64))
         self._df = df
 
     def __getattr__(self, attr):

--- a/src/laser/measles/compartmental/base.py
+++ b/src/laser/measles/compartmental/base.py
@@ -30,8 +30,8 @@ class BaseScenarioSchema(pt.Model):
 class BaseCompartmentalScenario(BaseScenario):
     def __init__(self, df: pl.DataFrame):
         super().__init__(df)
-        BaseScenarioSchema.validate(df, allow_superfluous_columns=True)
-        self._validate(df)
+        BaseScenarioSchema.validate(self._df, allow_superfluous_columns=True)
+        self._validate(self._df)
 
     def _validate(self, df: pl.DataFrame):
         # # Validate required columns exist - derive from schema

--- a/tests/unit/test_scenario_pop_coercion.py
+++ b/tests/unit/test_scenario_pop_coercion.py
@@ -57,5 +57,5 @@ def test_plain_python_list_pop_is_accepted():
 def test_float_pop_is_still_rejected():
     """Float pop must continue to raise — coercion is integer-only."""
     df = pl.DataFrame({"pop": [100_000.0], **_BASE_ROW})
-    with pytest.raises(ValueError, match="must be integer type"):
+    with pytest.raises(ValueError, match=r"Float64|must be integer type"):
         CompartmentalScenario(df)

--- a/tests/unit/test_scenario_pop_coercion.py
+++ b/tests/unit/test_scenario_pop_coercion.py
@@ -15,8 +15,8 @@ from laser.measles.compartmental.base import BaseScenario as CompartmentalScenar
 _BASE_ROW = {"lat": [1.0], "lon": [2.0], "id": ["n1"], "mcv1": [0.5]}
 
 _INTEGER_DTYPES = [
-    pl.Int16,   # max 32767 — fits _POP_VALUE
-    pl.Int32,   # max ~2.1B
+    pl.Int16,  # max 32767 — fits _POP_VALUE
+    pl.Int32,  # max ~2.1B
     pl.UInt16,  # max 65535 — fits _POP_VALUE
     pl.UInt32,  # max ~4.3B
 ]
@@ -57,5 +57,5 @@ def test_plain_python_list_pop_is_accepted():
 def test_float_pop_is_still_rejected():
     """Float pop must continue to raise — coercion is integer-only."""
     df = pl.DataFrame({"pop": [100_000.0], **_BASE_ROW})
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must be integer type"):
         CompartmentalScenario(df)

--- a/tests/unit/test_scenario_pop_coercion.py
+++ b/tests/unit/test_scenario_pop_coercion.py
@@ -1,0 +1,61 @@
+"""Regression tests for pop dtype coercion in BaseScenario.
+
+Any integer-width pop column must be silently coerced to Int64 at
+construction time. Compartmental, ABM, and biweekly scenarios must all
+accept non-Int64 integer pop without raising.
+"""
+
+import polars as pl
+import pytest
+
+from laser.measles.abm.base import BaseScenario as ABMScenario
+from laser.measles.biweekly.base import BaseScenario as BiweeklyScenario
+from laser.measles.compartmental.base import BaseScenario as CompartmentalScenario
+
+_BASE_ROW = {"lat": [1.0], "lon": [2.0], "id": ["n1"], "mcv1": [0.5]}
+
+_INTEGER_DTYPES = [
+    pl.Int16,   # max 32767 — fits _POP_VALUE
+    pl.Int32,   # max ~2.1B
+    pl.UInt16,  # max 65535 — fits _POP_VALUE
+    pl.UInt32,  # max ~4.3B
+]
+
+_POP_VALUE = 1_000  # fits in Int16/UInt16 and all wider types
+
+
+@pytest.mark.parametrize("dtype", _INTEGER_DTYPES)
+def test_abm_scenario_accepts_non_int64_pop(dtype):
+    df = pl.DataFrame({"pop": pl.Series([_POP_VALUE], dtype=dtype), **_BASE_ROW})
+    scenario = ABMScenario(df)
+    assert scenario._df["pop"].dtype == pl.Int64
+
+
+@pytest.mark.parametrize("dtype", _INTEGER_DTYPES)
+def test_biweekly_scenario_accepts_non_int64_pop(dtype):
+    df = pl.DataFrame({"pop": pl.Series([_POP_VALUE], dtype=dtype), **_BASE_ROW})
+    scenario = BiweeklyScenario(df)
+    assert scenario._df["pop"].dtype == pl.Int64
+
+
+@pytest.mark.parametrize("dtype", _INTEGER_DTYPES)
+def test_compartmental_scenario_accepts_non_int64_pop(dtype):
+    """Regression: compartmental __init__ was validating pre-coercion df, causing Int32 to fail."""
+    df = pl.DataFrame({"pop": pl.Series([_POP_VALUE], dtype=dtype), **_BASE_ROW})
+    scenario = CompartmentalScenario(df)
+    assert scenario._df["pop"].dtype == pl.Int64
+
+
+def test_plain_python_list_pop_is_accepted():
+    """Plain Python integer lists produce Int64 — must be accepted without any cast."""
+    df = pl.DataFrame({"pop": [100_000], **_BASE_ROW})
+    assert df["pop"].dtype == pl.Int64  # confirm Polars inference
+    scenario = CompartmentalScenario(df)
+    assert scenario._df["pop"].dtype == pl.Int64
+
+
+def test_float_pop_is_still_rejected():
+    """Float pop must continue to raise — coercion is integer-only."""
+    df = pl.DataFrame({"pop": [100_000.0], **_BASE_ROW})
+    with pytest.raises(ValueError):
+        CompartmentalScenario(df)


### PR DESCRIPTION
Fixes #147. 

The validator required exactly pl.Int64 for pop, but docs said Int32 and Polars infers Int64 from plain Python lists — causing silent failures for users who followed the docs or used untyped DataFrames.

BaseScenario.__init__ now silently casts any integer pop to Int64 before storing self._df. BaseCompartmentalScenario.__init__ was also fixed to validate self._df (post-coercion) instead of the original df argument. Docs (usage.md) and the concat_mkdocs.py RAG note are updated to match.