### PR TITLE
fix(base): default component name in add_component for non-BaseCompon…

### DIFF
--- a/src/laser/measles/base.py
+++ b/src/laser/measles/base.py
@@ -13,19 +13,16 @@ The BaseLaserModel class is the base class for all laser-measles models.
 from __future__ import annotations
 
 import gc
-import json
 from abc import ABC
 from abc import abstractmethod
 from datetime import datetime
 from datetime import timedelta
-from pathlib import Path
 from typing import Any
 from typing import Protocol
 from typing import TypeVar
 
 import alive_progress
 import matplotlib.pyplot as plt
-import numpy as np
 import polars as pl
 from laser.core.laserframe import LaserFrame
 from laser.core.random import seed as seed_prng

--- a/src/laser/measles/base.py
+++ b/src/laser/measles/base.py
@@ -340,6 +340,11 @@ class BaseLaserModel(ABC):
         self.phases = []
         for component in components:
             instance = component(self)
+            # BaseComponent.__init__ defaults `name`, but components that don't
+            # inherit from BaseComponent won't have it set. get_instance(str)
+            # compares against `name`, so default it defensively here.
+            if not hasattr(instance, "name"):
+                instance.name = instance.__class__.__name__
             self.instances.append(instance)
             if "__call__" in dir(instance):
                 self.phases.append(instance)
@@ -358,6 +363,8 @@ class BaseLaserModel(ABC):
         """
         self._components.append(component)
         instance = component(self)
+        if not hasattr(instance, "name"):
+            instance.name = instance.__class__.__name__
         self.instances.append(instance)
         if "__call__" in dir(instance):
             self.phases.append(instance)
@@ -372,6 +379,8 @@ class BaseLaserModel(ABC):
         """
         self._components.insert(0, component)
         instance = component(self)
+        if not hasattr(instance, "name"):
+            instance.name = instance.__class__.__name__
         self.instances.insert(0, instance)
         if "__call__" in dir(instance):
             self.phases.insert(0, instance)

--- a/src/laser/measles/base.py
+++ b/src/laser/measles/base.py
@@ -339,18 +339,28 @@ class BaseLaserModel(ABC):
         self.instances = []
         self.phases = []
         for component in components:
-            instance = component(self)
-            # BaseComponent.__init__ defaults `name`, but components that don't
-            # inherit from BaseComponent won't have it set. get_instance(str)
-            # compares against `name`, so default it defensively here.
-            if not hasattr(instance, "name"):
-                instance.name = instance.__class__.__name__
+            instance = self._instantiate_component(component)
             self.instances.append(instance)
             if "__call__" in dir(instance):
                 self.phases.append(instance)
 
         # Allow subclasses to perform additional component setup
         self._setup_components()
+
+    def _instantiate_component(self, component: type[BaseComponent]) -> BaseComponent:
+        """Instantiate a component and ensure it has a `name` attribute.
+
+        BaseComponent.__init__ defaults `name` to the class name, but
+        components that don't inherit from BaseComponent (or override __init__
+        without calling super) won't have it set. get_instance(str) compares
+        against `name`, so a missing attribute raises AttributeError
+        mid-comprehension the first time a string-form lookup runs. Set it
+        defensively here so any class works as a component.
+        """
+        instance = component(self)
+        if not hasattr(instance, "name"):
+            instance.name = instance.__class__.__name__
+        return instance
 
     def add_component(self, component: type[BaseComponent]) -> None:
         """
@@ -362,9 +372,7 @@ class BaseLaserModel(ABC):
             component: A component class to be initialized and integrated into the model.
         """
         self._components.append(component)
-        instance = component(self)
-        if not hasattr(instance, "name"):
-            instance.name = instance.__class__.__name__
+        instance = self._instantiate_component(component)
         self.instances.append(instance)
         if "__call__" in dir(instance):
             self.phases.append(instance)
@@ -378,9 +386,7 @@ class BaseLaserModel(ABC):
             component: A component class to be initialized and integrated into the model.
         """
         self._components.insert(0, component)
-        instance = component(self)
-        if not hasattr(instance, "name"):
-            instance.name = instance.__class__.__name__
+        instance = self._instantiate_component(component)
         self.instances.insert(0, instance)
         if "__call__" in dir(instance):
             self.phases.insert(0, instance)

--- a/src/laser/measles/base.py
+++ b/src/laser/measles/base.py
@@ -13,16 +13,19 @@ The BaseLaserModel class is the base class for all laser-measles models.
 from __future__ import annotations
 
 import gc
+import json
 from abc import ABC
 from abc import abstractmethod
 from datetime import datetime
 from datetime import timedelta
+from pathlib import Path
 from typing import Any
 from typing import Protocol
 from typing import TypeVar
 
 import alive_progress
 import matplotlib.pyplot as plt
+import numpy as np
 import polars as pl
 from laser.core.laserframe import LaserFrame
 from laser.core.random import seed as seed_prng

--- a/tests/unit/test_component_name_defaulting.py
+++ b/tests/unit/test_component_name_defaulting.py
@@ -1,0 +1,97 @@
+"""Regression test for the defensive `.name` defaulting in `_instantiate_component`.
+
+Components that don't inherit from `BaseComponent` (and don't set
+`self.name` in their own `__init__`) previously caused an `AttributeError`
+the first time `model.get_instance("ClassName")` was called — the lookup
+does `instance.name == cls` inside a list comprehension, which raises
+mid-iteration on the missing attribute.
+
+This file exercises all three component-creation paths
+(`components` setter, `add_component`, `prepend_component`) against a
+bare class that has neither inheritance nor a `.name` attribute, and
+asserts the string-form `get_instance` returns the instance and that
+the helper has set `.name` to the class name.
+
+Every other unit test uses framework components that DO inherit from
+`BaseComponent`, so the defensive defaulting in `_instantiate_component`
+is never reached without a test like this one.
+"""
+
+import polars as pl
+import pytest
+from laser.core import PropertySet
+
+import laser.measles as lm
+from laser.measles.base import BaseLaserModel
+from laser.measles.base import BaseScenario
+
+
+class _MockScenario(BaseScenario):
+    def _validate(self, df: pl.DataFrame) -> None:
+        pass
+
+
+class _BareComponent:
+    """Custom component with neither `BaseComponent` inheritance nor `.name`.
+
+    Represents the pattern an LLM commonly produces when asked for a
+    one-off tracker: ``class FooTracker: def __init__(self, model): ...``.
+    """
+
+    def __init__(self, model):
+        self.model = model
+
+
+class _TestModel(BaseLaserModel):
+    """Minimal BaseLaserModel subclass for component-management tests."""
+
+    def __init__(self):
+        scenario = _MockScenario(lm.scenarios.synthetic.single_patch_scenario())
+        params = PropertySet({"verbose": False, "start_time": "2000-01"})
+        super().__init__(scenario, params, "test")
+
+    def __call__(self, model, tick):
+        pass
+
+    def _setup_components(self) -> None:
+        pass
+
+
+@pytest.mark.parametrize("creation_path", ["setter", "add_component", "prepend_component"])
+def test_bare_class_component_findable_by_get_instance_str(creation_path):
+    model = _TestModel()
+
+    if creation_path == "setter":
+        model.components = [_BareComponent]
+    elif creation_path == "add_component":
+        model.add_component(_BareComponent)
+    elif creation_path == "prepend_component":
+        model.prepend_component(_BareComponent)
+    else:
+        pytest.fail(f"unknown creation_path {creation_path!r}")
+
+    # Without the defensive defaulting in _instantiate_component, this
+    # raised: AttributeError: '_BareComponent' object has no attribute 'name'
+    instances = model.get_instance("_BareComponent")
+    assert len(instances) == 1, f"expected 1 instance, got {len(instances)}"
+    assert isinstance(instances[0], _BareComponent)
+    # Helper should have set .name to the class name
+    assert instances[0].name == "_BareComponent"
+
+
+@pytest.mark.parametrize("creation_path", ["setter", "add_component", "prepend_component"])
+def test_bare_class_component_findable_by_get_instance_class(creation_path):
+    """Class-form lookup (`get_instance(cls)`) uses isinstance, so it always
+    worked. Cover it anyway — proves the fix didn't regress this path."""
+    model = _TestModel()
+
+    if creation_path == "setter":
+        model.components = [_BareComponent]
+    elif creation_path == "add_component":
+        model.add_component(_BareComponent)
+    elif creation_path == "prepend_component":
+        model.prepend_component(_BareComponent)
+
+    instances = model.get_instance(_BareComponent)
+    assert len(instances) == 1
+    assert isinstance(instances[0], _BareComponent)


### PR DESCRIPTION
…ent classes

BaseComponent.__init__ already defaults `name` to the class name, but custom components that don't inherit from BaseComponent (or override __init__ without calling super) miss that default. get_instance(str) compares against `instance.name`, so a missing attribute raises AttributeError mid-comprehension the first time a string-form lookup is done.

Set `instance.name` defensively at all three creation sites (constructor components loop, add_component, prepend_component) when the component doesn't already supply one. Same shape as PR #208 — close a framework-contract gap without requiring docs/users to know about it.