### PR TITLE
Feat/standard results output

### DIFF
--- a/docs/results.md
+++ b/docs/results.md
@@ -56,6 +56,7 @@ The method returns the dict that was written, so you can also inspect it in-proc
     "peak_infectious_global": 51925,
     "peak_day": 48,
     "attack_rate_global": 0.882,
+    "final_state_global": {"S": 67, "E": 0, "I": 0, "R": 249933},
     "attack_rate_per_patch": [0.879, 0.890, 0.890, "..."],
     "peak_infectious_per_patch": [25933, 41727, 61569, "..."],
     "final_state_per_patch": {
@@ -80,6 +81,7 @@ The method returns the dict that was written, so you can also inspect it in-proc
 | `summary.peak_infectious_global` | int | Maximum total infectious count summed across all patches over the run. |
 | `summary.peak_day` | int | Tick index at which `peak_infectious_global` occurred. |
 | `summary.attack_rate_global` | float | `final R / initial population` summed across all patches. `null` if `R` isn't in `states`. |
+| `summary.final_state_global` | object | Final count of each state summed across all patches. Keys are the state names present in `states`. Always emitted (works with both per-patch and global-only trackers). |
 | `summary.attack_rate_per_patch` | array of floats or null | Per-patch attack rate; `null` when only global tracking is available. |
 | `summary.peak_infectious_per_patch` | array of ints or null | Per-patch peak; `null` when only global tracking is available. |
 | `summary.final_state_per_patch` | object or null | Final count of each state per patch. Keys are the state names present in `states`. `null` when only global tracking is available. |

--- a/docs/results.md
+++ b/docs/results.md
@@ -39,7 +39,7 @@ The method returns the dict that was written, so you can also inspect it in-proc
 
 - A `StateTracker` component must be attached before `model.run()`. Otherwise `write_results()` raises a clear `RuntimeError` telling you to add one.
 - For per-patch breakdowns (attack rate per community, peak per patch, final S/E/I/R per patch), the tracker's `aggregation_level` must be `>= 0`. The default (`-1`) sums over all patches and produces global aggregates only.
-- `"I"` must be in `model.params.states` — required for peak-infectious and time-series fields.
+- `"I"` must be in `model.params.states` — required for peak-infectious metrics and `final_state_per_patch["I"]` in the written summary.
 
 ---
 

--- a/docs/results.md
+++ b/docs/results.md
@@ -93,10 +93,19 @@ import json
 results = json.loads(open("results.json").read())
 
 print(f"Peak infectious: {results['summary']['peak_infectious_global']} on day {results['summary']['peak_day']}")
-print(f"Overall attack rate: {results['summary']['attack_rate_global']:.1%}")
 
-for patch_id, rate in zip(results["patch_ids"], results["summary"]["attack_rate_per_patch"]):
-    print(f"  {patch_id}: {rate:.1%}")
+attack_rate_global = results["summary"]["attack_rate_global"]
+if attack_rate_global is not None:
+    print(f"Overall attack rate: {attack_rate_global:.1%}")
+else:
+    print("Overall attack rate: unavailable")
+
+attack_rate_per_patch = results["summary"]["attack_rate_per_patch"]
+if attack_rate_per_patch is not None:
+    for patch_id, rate in zip(results["patch_ids"], attack_rate_per_patch):
+        print(f"  {patch_id}: {rate:.1%}")
+else:
+    print("Per-patch attack rates: unavailable")
 ```
 
 ---

--- a/docs/results.md
+++ b/docs/results.md
@@ -1,0 +1,112 @@
+# Standard results output
+
+`model.write_results()` writes a canonical JSON summary of a simulation to disk after `model.run()`. Use it as the contract that downstream tooling — validators, plotting scripts, model-comparison reports — reads from, instead of parsing simulation stdout or pulling fields off trackers ad-hoc.
+
+## Why use it?
+
+- **Stable schema across model variants.** ABM, compartmental, and biweekly models all produce the same top-level keys, so the same downstream code works for any of them.
+- **One method instead of many.** No need to remember which tracker exposes peak infectious vs attack rate vs final state — all the common quantities land in one file with predictable names.
+- **Decouples stdout from automation.** Progress bars, warnings, and debug prints stay in stdout for humans; numeric results stay in `results.json` for code.
+
+---
+
+## Basic usage
+
+```python
+import laser.measles as lm
+from laser.measles.abm.components import StateTracker
+from laser.measles.components import BaseStateTrackerParams, create_component
+
+params = lm.ABMParams(num_ticks=365, seed=42, start_time="2000-01")
+model = lm.ABMModel(scenario, params)
+model.add_component(lm.NoBirthsProcess)
+model.add_component(lm.InfectionProcess)
+
+# IMPORTANT: aggregation_level=0 keeps per-patch arrays. Without it,
+# write_results() can only emit global aggregates (attack_rate_per_patch=None).
+model.add_component(create_component(StateTracker,
+                                     params=BaseStateTrackerParams(aggregation_level=0)))
+
+model.run()
+model.write_results("results.json")  # defaults to "results.json" in cwd
+```
+
+The method returns the dict that was written, so you can also inspect it in-process without re-reading the file.
+
+---
+
+## Requirements
+
+- A `StateTracker` component must be attached before `model.run()`. Otherwise `write_results()` raises a clear `RuntimeError` telling you to add one.
+- For per-patch breakdowns (attack rate per community, peak per patch, final S/E/I/R per patch), the tracker's `aggregation_level` must be `>= 0`. The default (`-1`) sums over all patches and produces global aggregates only.
+- `"I"` must be in `model.params.states` — required for peak-infectious and time-series fields.
+
+---
+
+## Output schema
+
+```json
+{
+  "model_type": "ABMModel",
+  "num_ticks": 365,
+  "num_patches": 8,
+  "patch_ids": ["patch_0", "patch_1", "patch_2", "..."],
+  "states": ["S", "E", "I", "R"],
+  "summary": {
+    "peak_infectious_global": 51925,
+    "peak_day": 48,
+    "attack_rate_global": 0.882,
+    "attack_rate_per_patch": [0.879, 0.890, 0.890, "..."],
+    "peak_infectious_per_patch": [25933, 41727, 61569, "..."],
+    "final_state_per_patch": {
+      "S": [42, 17, 8,  "..."],
+      "E": [0,  0,  0,  "..."],
+      "I": [0,  0,  0,  "..."],
+      "R": [49958, 79983, 119992, "..."]
+    }
+  }
+}
+```
+
+### Field reference
+
+| Key | Type | Notes |
+|---|---|---|
+| `model_type` | string | Class name of the model (`"ABMModel"`, `"CompartmentalModel"`, `"BiweeklyModel"`). |
+| `num_ticks` | int | Total simulation length in ticks (days for ABM/compartmental, 14-day units for biweekly). |
+| `num_patches` | int | Number of patches/groups represented in the per-patch arrays. Equals `len(patch_ids)` when per-patch tracking is on; `1` for global-only. |
+| `patch_ids` | array of strings | Patch identifiers in the same order as the per-patch arrays. `["all_patches"]` for global-only output. |
+| `states` | array of strings | The disease states tracked, in order — `["S", "E", "I", "R"]` for SEIR; `["S", "I", "R"]` for SIR. |
+| `summary.peak_infectious_global` | int | Maximum total infectious count summed across all patches over the run. |
+| `summary.peak_day` | int | Tick index at which `peak_infectious_global` occurred. |
+| `summary.attack_rate_global` | float | `final R / initial population` summed across all patches. `null` if `R` isn't in `states`. |
+| `summary.attack_rate_per_patch` | array of floats or null | Per-patch attack rate; `null` when only global tracking is available. |
+| `summary.peak_infectious_per_patch` | array of ints or null | Per-patch peak; `null` when only global tracking is available. |
+| `summary.final_state_per_patch` | object or null | Final count of each state per patch. Keys are the state names present in `states`. `null` when only global tracking is available. |
+
+---
+
+## Reading the results back
+
+```python
+import json
+results = json.loads(open("results.json").read())
+
+print(f"Peak infectious: {results['summary']['peak_infectious_global']} on day {results['summary']['peak_day']}")
+print(f"Overall attack rate: {results['summary']['attack_rate_global']:.1%}")
+
+for patch_id, rate in zip(results["patch_ids"], results["summary"]["attack_rate_per_patch"]):
+    print(f"  {patch_id}: {rate:.1%}")
+```
+
+---
+
+## Comparing models
+
+Because all three model variants emit the same schema, a cross-model comparison is just three reads:
+
+```python
+results = {name: json.load(open(f"results_{name}.json")) for name in ("abm", "compartmental", "biweekly")}
+for name, r in results.items():
+    print(f"{name}: peak={r['summary']['peak_infectious_global']} on day {r['summary']['peak_day']}")
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
   - Installation: install.md
   - Usage: usage.md
   - Snapshotting: snapshotting.md
+  - Results output: results.md
   - Tutorials:
     - tutorials/index.md
     - Quick start: tutorials/tut_quickstart_hello_world.ipynb

--- a/src/laser/measles/base.py
+++ b/src/laser/measles/base.py
@@ -463,7 +463,7 @@ class BaseLaserModel(ABC):
             )
 
         arr = _np.asarray(tracker.state_tracker)  # (num_states, num_ticks, num_groups)
-        num_states, num_ticks, num_groups = arr.shape
+        _, num_ticks, num_groups = arr.shape
         state_names = list(self.params.states)
         state_idx = {s: i for i, s in enumerate(state_names)}
         patch_ids = list(tracker.group_ids)

--- a/src/laser/measles/base.py
+++ b/src/laser/measles/base.py
@@ -446,6 +446,7 @@ class BaseLaserModel(ABC):
                 peak_infectious_global:     int
                 peak_day:                   int
                 attack_rate_global:         float
+                final_state_global:         dict[str, int]
                 attack_rate_per_patch:      list[float] | None
                 peak_infectious_per_patch:  list[int]   | None
                 final_state_per_patch:      dict[str, list[int]] | None
@@ -500,6 +501,11 @@ class BaseLaserModel(ABC):
         if per_patch:
             final_per_patch = {name: x[-1].astype(int).tolist() for name, x in (("S", S), ("E", E), ("I", I), ("R", R)) if x is not None}
 
+        # Global final compartment counts — always produced, by summing the
+        # final tick across patches/groups. Available even when only a global
+        # StateTracker is attached (no per-patch breakdown required).
+        final_global = {name: int(x[-1].sum()) for name, x in (("S", S), ("E", E), ("I", I), ("R", R)) if x is not None}
+
         out = {
             "model_type": self.__class__.__name__,
             "num_ticks": int(num_ticks),
@@ -510,6 +516,7 @@ class BaseLaserModel(ABC):
                 "peak_infectious_global": peak_global,
                 "peak_day": peak_day,
                 "attack_rate_global": attack_global,
+                "final_state_global": final_global,
                 "attack_rate_per_patch": attack_per_patch if per_patch else None,
                 "peak_infectious_per_patch": peak_per_patch,
                 "final_state_per_patch": final_per_patch,

--- a/src/laser/measles/base.py
+++ b/src/laser/measles/base.py
@@ -512,7 +512,7 @@ class BaseLaserModel(ABC):
         out = {
             "model_type": self.__class__.__name__,
             "num_ticks": int(num_ticks),
-            "num_patches": int(num_groups) if per_patch else int(len(getattr(self, "scenario", []) or [])) or 1,
+            "num_patches": int(len(patch_ids)),
             "patch_ids": patch_ids,
             "states": state_names,
             "summary": {

--- a/src/laser/measles/base.py
+++ b/src/laser/measles/base.py
@@ -13,16 +13,19 @@ The BaseLaserModel class is the base class for all laser-measles models.
 from __future__ import annotations
 
 import gc
+import json
 from abc import ABC
 from abc import abstractmethod
 from datetime import datetime
 from datetime import timedelta
+from pathlib import Path
 from typing import Any
 from typing import Protocol
 from typing import TypeVar
 
 import alive_progress
 import matplotlib.pyplot as plt
+import numpy as np
 import polars as pl
 from laser.core.laserframe import LaserFrame
 from laser.core.random import seed as seed_prng
@@ -447,10 +450,6 @@ class BaseLaserModel(ABC):
                 peak_infectious_per_patch:  list[int]   | None
                 final_state_per_patch:      dict[str, list[int]] | None
         """
-        import json as _json
-
-        import numpy as _np
-
         tracker = None
         for instance in self.instances:
             if getattr(instance, "name", None) == "StateTracker":
@@ -458,11 +457,10 @@ class BaseLaserModel(ABC):
                 break
         if tracker is None:
             raise RuntimeError(
-                "write_results() requires a StateTracker component. Add "
-                "StateTracker() to your components list before model.run()."
+                "write_results() requires a StateTracker component. Add StateTracker() to your components list before model.run()."
             )
 
-        arr = _np.asarray(tracker.state_tracker)  # (num_states, num_ticks, num_groups)
+        arr = np.asarray(tracker.state_tracker)  # (num_states, num_ticks, num_groups)
         _, num_ticks, num_groups = arr.shape
         state_names = list(self.params.states)
         state_idx = {s: i for i, s in enumerate(state_names)}
@@ -472,13 +470,10 @@ class BaseLaserModel(ABC):
         def _series(name):
             return arr[state_idx[name]] if name in state_idx else None  # (num_ticks, num_groups)
 
-        S, E, I, R = (_series(s) for s in ("S", "E", "I", "R"))
+        S, E, I, R = (_series(s) for s in ("S", "E", "I", "R"))  # noqa: E741 — SEIR convention
 
         if I is None:
-            raise RuntimeError(
-                "write_results() requires an 'I' state in model.params.states; "
-                f"got {state_names!r}"
-            )
+            raise RuntimeError(f"write_results() requires an 'I' state in model.params.states; got {state_names!r}")
 
         # Global infectious time series (sum over patches/groups)
         I_global = I.sum(axis=1)
@@ -490,12 +485,12 @@ class BaseLaserModel(ABC):
         # malformed inputs.
         pop_per_patch = sum(
             (x[0] for x in (S, E, I, R) if x is not None),
-            start=_np.zeros(num_groups, dtype=arr.dtype),
+            start=np.zeros(num_groups, dtype=arr.dtype),
         )
 
         if R is not None:
             attack_global = float(R[-1].sum() / max(int(pop_per_patch.sum()), 1))
-            attack_per_patch = (R[-1] / _np.maximum(pop_per_patch, 1)).astype(float).tolist()
+            attack_per_patch = (R[-1] / np.maximum(pop_per_patch, 1)).astype(float).tolist()
         else:
             attack_global = None
             attack_per_patch = None
@@ -503,16 +498,12 @@ class BaseLaserModel(ABC):
         peak_per_patch = I.max(axis=0).astype(int).tolist() if per_patch else None
         final_per_patch = None
         if per_patch:
-            final_per_patch = {
-                name: x[-1].astype(int).tolist()
-                for name, x in (("S", S), ("E", E), ("I", I), ("R", R))
-                if x is not None
-            }
+            final_per_patch = {name: x[-1].astype(int).tolist() for name, x in (("S", S), ("E", E), ("I", I), ("R", R)) if x is not None}
 
         out = {
             "model_type": self.__class__.__name__,
             "num_ticks": int(num_ticks),
-            "num_patches": int(len(patch_ids)),
+            "num_patches": len(patch_ids),
             "patch_ids": patch_ids,
             "states": state_names,
             "summary": {
@@ -525,8 +516,8 @@ class BaseLaserModel(ABC):
             },
         }
 
-        with open(path, "w", encoding="utf-8") as f:
-            _json.dump(out, f, indent=2, default=lambda o: o.tolist() if hasattr(o, "tolist") else str(o))
+        with Path(path).open("w", encoding="utf-8") as f:
+            json.dump(out, f, indent=2, default=lambda o: o.tolist() if hasattr(o, "tolist") else str(o))
         return out
 
     def time_elapsed(self, units: str = "days") -> int | float:

--- a/src/laser/measles/base.py
+++ b/src/laser/measles/base.py
@@ -412,6 +412,123 @@ class BaseLaserModel(ABC):
             print(f"Completed the {self.name} model at {self._tfinish}…")
             self._print_timing_summary()
 
+    def write_results(self, path: str = "results.json") -> dict:
+        """Write a standard summary of the simulation to JSON.
+
+        Produces a single, model-variant-agnostic file with the quantities most
+        commonly asked for after a run: peak infectious, attack rate, and final
+        compartment counts — both globally and per patch when a per-patch
+        StateTracker is present. Intended to be the canonical output that
+        downstream tooling (validators, plotting, model comparison) reads
+        instead of parsing stdout.
+
+        Requires a `StateTracker` component to be attached. If you want
+        per-patch arrays in the output, add the tracker with
+        `aggregation_level=0` (or the depth of your ID hierarchy minus one).
+        Otherwise only global aggregates are produced.
+
+        Args:
+            path: Destination file. Defaults to ``"results.json"`` in cwd.
+
+        Returns:
+            The dict that was written (also handy for in-process inspection).
+
+        Schema (top-level keys):
+            model_type:   class name of the model (e.g. "ABMModel")
+            num_ticks:    int
+            num_patches:  int (patch count from the tracker; 1 if global only)
+            patch_ids:    list[str] (matches tracker.group_ids)
+            states:       list[str] (e.g. ["S","E","I","R"])
+            summary:
+                peak_infectious_global:     int
+                peak_day:                   int
+                attack_rate_global:         float
+                attack_rate_per_patch:      list[float] | None
+                peak_infectious_per_patch:  list[int]   | None
+                final_state_per_patch:      dict[str, list[int]] | None
+        """
+        import json as _json
+
+        import numpy as _np
+
+        tracker = None
+        for instance in self.instances:
+            if getattr(instance, "name", None) == "StateTracker":
+                tracker = instance
+                break
+        if tracker is None:
+            raise RuntimeError(
+                "write_results() requires a StateTracker component. Add "
+                "StateTracker() to your components list before model.run()."
+            )
+
+        arr = _np.asarray(tracker.state_tracker)  # (num_states, num_ticks, num_groups)
+        num_states, num_ticks, num_groups = arr.shape
+        state_names = list(self.params.states)
+        state_idx = {s: i for i, s in enumerate(state_names)}
+        patch_ids = list(tracker.group_ids)
+        per_patch = patch_ids != ["all_patches"]
+
+        def _series(name):
+            return arr[state_idx[name]] if name in state_idx else None  # (num_ticks, num_groups)
+
+        S, E, I, R = (_series(s) for s in ("S", "E", "I", "R"))
+
+        if I is None:
+            raise RuntimeError(
+                "write_results() requires an 'I' state in model.params.states; "
+                f"got {state_names!r}"
+            )
+
+        # Global infectious time series (sum over patches/groups)
+        I_global = I.sum(axis=1)
+        peak_global = int(I_global.max())
+        peak_day = int(I_global.argmax())
+
+        # Initial population per patch (sum over states at tick 0). Used as the
+        # attack-rate denominator. Falls back to 1 to avoid div-by-zero on
+        # malformed inputs.
+        pop_per_patch = sum(
+            (x[0] for x in (S, E, I, R) if x is not None),
+            start=_np.zeros(num_groups, dtype=arr.dtype),
+        )
+
+        if R is not None:
+            attack_global = float(R[-1].sum() / max(int(pop_per_patch.sum()), 1))
+            attack_per_patch = (R[-1] / _np.maximum(pop_per_patch, 1)).astype(float).tolist()
+        else:
+            attack_global = None
+            attack_per_patch = None
+
+        peak_per_patch = I.max(axis=0).astype(int).tolist() if per_patch else None
+        final_per_patch = None
+        if per_patch:
+            final_per_patch = {
+                name: x[-1].astype(int).tolist()
+                for name, x in (("S", S), ("E", E), ("I", I), ("R", R))
+                if x is not None
+            }
+
+        out = {
+            "model_type": self.__class__.__name__,
+            "num_ticks": int(num_ticks),
+            "num_patches": int(num_groups) if per_patch else int(len(getattr(self, "scenario", []) or [])) or 1,
+            "patch_ids": patch_ids,
+            "states": state_names,
+            "summary": {
+                "peak_infectious_global": peak_global,
+                "peak_day": peak_day,
+                "attack_rate_global": attack_global,
+                "attack_rate_per_patch": attack_per_patch if per_patch else None,
+                "peak_infectious_per_patch": peak_per_patch,
+                "final_state_per_patch": final_per_patch,
+            },
+        }
+
+        with open(path, "w", encoding="utf-8") as f:
+            _json.dump(out, f, indent=2, default=lambda o: o.tolist() if hasattr(o, "tolist") else str(o))
+        return out
+
     def time_elapsed(self, units: str = "days") -> int | float:
         """
         Return time elapsed since the start of the model.

--- a/tests/unit/test_write_results.py
+++ b/tests/unit/test_write_results.py
@@ -1,0 +1,140 @@
+"""Tests for BaseLaserModel.write_results() — the standard JSON output.
+
+Coverage:
+- Per-patch tracker (aggregation_level=0): full schema with non-null per-patch
+  arrays in the right shape, correct patch_ids order, summary scalars sane.
+- Global-only tracker (default aggregation_level=-1): per-patch arrays are
+  None; global aggregates still populated.
+- No StateTracker attached: write_results() raises a clear RuntimeError.
+- Return value matches what's written to disk.
+"""
+
+import json
+
+import polars as pl
+import pytest
+
+import laser.measles as lm
+from laser.measles.abm import ABMModel, ABMParams
+from laser.measles.abm.components import (
+    InfectionProcess,
+    InfectionSeedingParams,
+    InfectionSeedingProcess,
+    NoBirthsProcess,
+    StateTracker,
+)
+from laser.measles.components import BaseStateTrackerParams, create_component
+
+
+N_PATCHES = 5
+TICKS = 90
+
+
+def _scenario():
+    return pl.DataFrame({
+        "id": [f"patch_{i}" for i in range(N_PATCHES)],
+        "pop": [50_000, 80_000, 120_000, 60_000, 40_000],
+        "lat": [0.0, 0.1, 0.2, 0.3, 0.4],
+        "lon": [0.0, 0.0, 0.0, 0.0, 0.0],
+        "mcv1": [0.0, 0.2, 0.4, 0.6, 0.8],
+    })
+
+
+def _make_model(state_tracker_params=None):
+    params = ABMParams(num_ticks=TICKS, seed=42, start_time="2000-01",
+                       verbose=False, show_progress=False)
+    model = ABMModel(_scenario(), params)
+    model.add_component(NoBirthsProcess)
+    model.add_component(create_component(InfectionSeedingProcess,
+                                         params=InfectionSeedingParams(num_infections=20)))
+    model.add_component(InfectionProcess)
+    if state_tracker_params is not None:
+        model.add_component(create_component(StateTracker, params=state_tracker_params))
+    return model
+
+
+def test_per_patch_output_has_full_schema(tmp_path):
+    model = _make_model(BaseStateTrackerParams(aggregation_level=0))
+    model.run()
+
+    out_path = tmp_path / "results.json"
+    returned = model.write_results(str(out_path))
+
+    assert out_path.exists(), "write_results() did not write the file"
+    on_disk = json.loads(out_path.read_text())
+    assert on_disk == returned, "return value must match what's written"
+
+    # Top-level keys
+    for key in ("model_type", "num_ticks", "num_patches", "patch_ids", "states", "summary"):
+        assert key in on_disk, f"missing top-level key {key!r}"
+
+    assert on_disk["model_type"] == "ABMModel"
+    assert on_disk["num_ticks"] == TICKS
+    assert on_disk["num_patches"] == N_PATCHES
+    assert on_disk["patch_ids"] == [f"patch_{i}" for i in range(N_PATCHES)]
+    assert set(("S", "I", "R")).issubset(set(on_disk["states"]))
+
+    summary = on_disk["summary"]
+
+    # Global scalars
+    assert isinstance(summary["peak_infectious_global"], int)
+    assert summary["peak_infectious_global"] > 0
+    assert 0 <= summary["peak_day"] < TICKS
+    assert 0.0 <= summary["attack_rate_global"] <= 1.0
+
+    # Per-patch arrays present and correctly sized
+    assert summary["attack_rate_per_patch"] is not None
+    assert len(summary["attack_rate_per_patch"]) == N_PATCHES
+    assert all(0.0 <= r <= 1.0 for r in summary["attack_rate_per_patch"])
+
+    assert summary["peak_infectious_per_patch"] is not None
+    assert len(summary["peak_infectious_per_patch"]) == N_PATCHES
+    assert all(p >= 0 for p in summary["peak_infectious_per_patch"])
+
+    # final_state_per_patch is a dict of state -> N_PATCHES counts
+    final = summary["final_state_per_patch"]
+    assert final is not None
+    for state in ("S", "I", "R"):
+        assert state in final, f"missing final state {state!r}"
+        assert len(final[state]) == N_PATCHES
+
+
+def test_global_only_tracker_emits_null_per_patch_arrays(tmp_path):
+    # Default aggregation_level=-1 → tracker sums over all patches → per-patch
+    # arrays in the JSON should be None.
+    model = _make_model(BaseStateTrackerParams())  # default
+    model.run()
+
+    out = model.write_results(str(tmp_path / "results.json"))
+    summary = out["summary"]
+
+    # Global aggregates still produced
+    assert isinstance(summary["peak_infectious_global"], int)
+    assert summary["peak_infectious_global"] > 0
+    assert summary["attack_rate_global"] is not None
+
+    # Per-patch arrays explicitly null
+    assert summary["attack_rate_per_patch"] is None
+    assert summary["peak_infectious_per_patch"] is None
+    assert summary["final_state_per_patch"] is None
+
+    # patch_ids reflects the single aggregated group
+    assert out["patch_ids"] == ["all_patches"]
+
+
+def test_missing_state_tracker_raises(tmp_path):
+    model = _make_model(state_tracker_params=None)  # no tracker
+    model.run()
+
+    with pytest.raises(RuntimeError, match="StateTracker"):
+        model.write_results(str(tmp_path / "results.json"))
+
+
+def test_default_path_is_results_json_in_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    model = _make_model(BaseStateTrackerParams(aggregation_level=0))
+    model.run()
+    model.write_results()  # no path arg
+
+    default_path = tmp_path / "results.json"
+    assert default_path.exists(), "default path 'results.json' should land in cwd"

--- a/tests/unit/test_write_results.py
+++ b/tests/unit/test_write_results.py
@@ -14,39 +14,37 @@ import json
 import polars as pl
 import pytest
 
-import laser.measles as lm
-from laser.measles.abm import ABMModel, ABMParams
-from laser.measles.abm.components import (
-    InfectionProcess,
-    InfectionSeedingParams,
-    InfectionSeedingProcess,
-    NoBirthsProcess,
-    StateTracker,
-)
-from laser.measles.components import BaseStateTrackerParams, create_component
-
+from laser.measles.abm import ABMModel
+from laser.measles.abm import ABMParams
+from laser.measles.abm.components import InfectionProcess
+from laser.measles.abm.components import InfectionSeedingParams
+from laser.measles.abm.components import InfectionSeedingProcess
+from laser.measles.abm.components import NoBirthsProcess
+from laser.measles.abm.components import StateTracker
+from laser.measles.components import BaseStateTrackerParams
+from laser.measles.components import create_component
 
 N_PATCHES = 5
 TICKS = 90
 
 
 def _scenario():
-    return pl.DataFrame({
-        "id": [f"patch_{i}" for i in range(N_PATCHES)],
-        "pop": [50_000, 80_000, 120_000, 60_000, 40_000],
-        "lat": [0.0, 0.1, 0.2, 0.3, 0.4],
-        "lon": [0.0, 0.0, 0.0, 0.0, 0.0],
-        "mcv1": [0.0, 0.2, 0.4, 0.6, 0.8],
-    })
+    return pl.DataFrame(
+        {
+            "id": [f"patch_{i}" for i in range(N_PATCHES)],
+            "pop": [50_000, 80_000, 120_000, 60_000, 40_000],
+            "lat": [0.0, 0.1, 0.2, 0.3, 0.4],
+            "lon": [0.0, 0.0, 0.0, 0.0, 0.0],
+            "mcv1": [0.0, 0.2, 0.4, 0.6, 0.8],
+        }
+    )
 
 
 def _make_model(state_tracker_params=None):
-    params = ABMParams(num_ticks=TICKS, seed=42, start_time="2000-01",
-                       verbose=False, show_progress=False)
+    params = ABMParams(num_ticks=TICKS, seed=42, start_time="2000-01", verbose=False, show_progress=False)
     model = ABMModel(_scenario(), params)
     model.add_component(NoBirthsProcess)
-    model.add_component(create_component(InfectionSeedingProcess,
-                                         params=InfectionSeedingParams(num_infections=20)))
+    model.add_component(create_component(InfectionSeedingProcess, params=InfectionSeedingParams(num_infections=20)))
     model.add_component(InfectionProcess)
     if state_tracker_params is not None:
         model.add_component(create_component(StateTracker, params=state_tracker_params))
@@ -72,7 +70,7 @@ def test_per_patch_output_has_full_schema(tmp_path):
     assert on_disk["num_ticks"] == TICKS
     assert on_disk["num_patches"] == N_PATCHES
     assert on_disk["patch_ids"] == [f"patch_{i}" for i in range(N_PATCHES)]
-    assert set(("S", "I", "R")).issubset(set(on_disk["states"]))
+    assert {"S", "I", "R"}.issubset(set(on_disk["states"]))
 
     summary = on_disk["summary"]
 

--- a/tests/unit/test_write_results.py
+++ b/tests/unit/test_write_results.py
@@ -96,6 +96,15 @@ def test_per_patch_output_has_full_schema(tmp_path):
         assert state in final, f"missing final state {state!r}"
         assert len(final[state]) == N_PATCHES
 
+    # final_state_global is a dict of state -> scalar int (sum across patches)
+    final_global = summary["final_state_global"]
+    assert final_global is not None
+    for state in ("S", "I", "R"):
+        assert state in final_global, f"missing global final state {state!r}"
+        assert isinstance(final_global[state], int)
+        # Global value equals sum of per-patch values
+        assert final_global[state] == sum(final[state]), f"global {state}={final_global[state]} != sum(per-patch)={sum(final[state])}"
+
 
 def test_global_only_tracker_emits_null_per_patch_arrays(tmp_path):
     # Default aggregation_level=-1 → tracker sums over all patches → per-patch
@@ -110,6 +119,14 @@ def test_global_only_tracker_emits_null_per_patch_arrays(tmp_path):
     assert isinstance(summary["peak_infectious_global"], int)
     assert summary["peak_infectious_global"] > 0
     assert summary["attack_rate_global"] is not None
+
+    # final_state_global is present even when only global tracking is on
+    final_global = summary["final_state_global"]
+    assert final_global is not None
+    for state in ("S", "I", "R"):
+        assert state in final_global
+        assert isinstance(final_global[state], int)
+        assert final_global[state] >= 0
 
     # Per-patch arrays explicitly null
     assert summary["attack_rate_per_patch"] is None


### PR DESCRIPTION
feat(base): add BaseLaserModel.write_results() for standard JSON output
Add a single method that produces a canonical results.json after model.run(),
intended to be the contract that downstream tooling (validators, plotting,
model comparison) reads against — instead of regex-parsing stdout, which is
brittle across model variants and LLM-chosen print formats.

Schema (top-level keys):
  model_type, num_ticks, num_patches, patch_ids, states
  summary: peak_infectious_global, peak_day, attack_rate_global,
           attack_rate_per_patch, peak_infectious_per_patch,
           final_state_per_patch

Pulls from any attached StateTracker. Per-patch arrays are populated when the
tracker uses aggregation_level >= 0; otherwise only global aggregates are
emitted. Raises a clear RuntimeError if no StateTracker is attached.

Works uniformly across ABM, compartmental, and biweekly variants because all
three expose the same BaseStateTracker shape (num_states, num_ticks, num_groups).