### PR TITLE
docs(transmission): correct incidence docstring; remove stale entries

### DIFF
--- a/src/laser/measles/abm/components/process_transmission.py
+++ b/src/laser/measles/abm/components/process_transmission.py
@@ -148,7 +148,10 @@ class TransmissionProcess(BasePhase):
             - 'incidence' (uint32, per patch): number of *new* infections that
               occurred during the most recent tick. Reset (overwritten, not
               accumulated) at every tick. To get cumulative incidence over a
-              run, sum this each tick yourself or read from a StateTracker.
+              run, sum this value across ticks yourself, or derive it from
+              tracked SEIR state counts (for example, from changes in S/E over
+              time) rather than reading a direct incidence series from a
+              StateTracker.
         """
 
         super().__init__(model)

--- a/src/laser/measles/abm/components/process_transmission.py
+++ b/src/laser/measles/abm/components/process_transmission.py
@@ -143,11 +143,12 @@ class TransmissionProcess(BasePhase):
 
             model: The model object passed during initialization.
 
-        The model's patches are extended with the following properties:
+        The model's patches are extended with the following scalar property:
 
-            - 'cases': A vector property with length equal to the number of ticks, dtype is uint32.
-            - 'forces': A scalar property with dtype float32.
-            - 'incidence': A vector property with length equal to the number of ticks, dtype is uint32.
+            - 'incidence' (uint32, per patch): number of *new* infections that
+              occurred during the most recent tick. Reset (overwritten, not
+              accumulated) at every tick. To get cumulative incidence over a
+              run, sum this each tick yourself or read from a StateTracker.
         """
 
         super().__init__(model)

--- a/src/laser/measles/abm/components/process_transmission.py
+++ b/src/laser/measles/abm/components/process_transmission.py
@@ -145,12 +145,10 @@ class TransmissionProcess(BasePhase):
 
         The model's patches are extended with the following scalar property:
 
-            - 'incidence' (uint32, per patch): number of *new* infections that
-              occurred during the most recent tick. Reset (overwritten, not
-              accumulated) at every tick. To get cumulative incidence over a
-              run, sum this value across ticks yourself, or derive it from
-              tracked SEIR state counts (for example, from changes in S/E over
-              time) rather than reading a direct incidence series from a
+            - 'incidence' (uint32, per patch): number of *new* infections
+              during the most recent tick; overwritten each tick. For
+              cumulative incidence over a run, sum this each tick yourself,
+              or compute from per-tick decreases in ``S`` recorded by a
               StateTracker.
         """
 


### PR DESCRIPTION
TransmissionProcess.__init__ docstring claimed it adds three patch properties:
  - 'cases': vector with length=num_ticks
  - 'forces': scalar float32
  - 'incidence': vector with length=num_ticks

In reality only 'incidence' is added here, and it's a *scalar* (per-patch) that is reset every tick — not cumulative and not a time series. The misleading shape ('vector with length=num_ticks') and the wrong cumulative implication have bitten LLM-generated extraction code: scripts reading model.patches.incidence at the end of a run see the last tick's value (zero once an outbreak has burned out) and report 0% attack rate even though the simulation ran correctly.

Replace the three-line bullet with one accurate description of 'incidence', noting it resets each tick and pointing readers to StateTracker (or a manual per-tick sum) for cumulative incidence.

No code change; doc-only.