### PR TITLE
feat(components): expose mixing_matrix as a property on InfectionProcess

### DIFF
--- a/src/laser/measles/abm/components/process_infection.py
+++ b/src/laser/measles/abm/components/process_infection.py
@@ -124,6 +124,22 @@ class InfectionProcess(BaseInfectionProcess):
     def infect(self, model: ABMModel, idx: np.ndarray) -> None:
         self.transmission.infect(model, idx)
 
+    @property
+    def mixing_matrix(self) -> np.ndarray:
+        """The spatial mixing matrix the wrapped TransmissionProcess is using.
+
+        Convenience accessor that walks down to the live mixer instance:
+        ``self.transmission.params.mixer.mixing_matrix``. Once the model has
+        run, ``mixer.scenario`` is set and the matrix is lazily computed on
+        first access. Shape is ``(n_patches, n_patches)``.
+
+        Provided here so code that has a handle on the InfectionProcess
+        (e.g. ``model.get_instance("InfectionProcess")[0]``) can get the
+        matrix in one hop, without knowing that TransmissionProcess is
+        nested inside as a sub-component rather than registered separately.
+        """
+        return self.transmission.params.mixer.mixing_matrix
+
     def plot(self, fig: Figure | None = None):
         """
         Plot cases and incidence using the transmission component's plotting functionality.

--- a/src/laser/measles/biweekly/components/process_infection.py
+++ b/src/laser/measles/biweekly/components/process_infection.py
@@ -69,6 +69,15 @@ class InfectionProcess(BaseInfectionProcess):
         self.params = params
         self.params.mixer.scenario = model.scenario
 
+    @property
+    def mixing_matrix(self):
+        """The spatial mixing matrix in use. Shape ``(n_patches, n_patches)``.
+
+        Mirrors the same-named property on the ABM InfectionProcess so prompts
+        can use one accessor regardless of model variant.
+        """
+        return self.params.mixer.mixing_matrix
+
     def __call__(self, model: BaseLaserModel, tick: int) -> None:
         # state counts
         states = model.patches.states

--- a/src/laser/measles/biweekly/components/process_infection.py
+++ b/src/laser/measles/biweekly/components/process_infection.py
@@ -70,7 +70,7 @@ class InfectionProcess(BaseInfectionProcess):
         self.params.mixer.scenario = model.scenario
 
     @property
-    def mixing_matrix(self):
+    def mixing_matrix(self) -> np.ndarray:
         """The spatial mixing matrix in use. Shape ``(n_patches, n_patches)``.
 
         Mirrors the same-named property on the ABM InfectionProcess so prompts

--- a/src/laser/measles/compartmental/components/process_infection.py
+++ b/src/laser/measles/compartmental/components/process_infection.py
@@ -120,6 +120,15 @@ class InfectionProcess(BaseInfectionProcess):
         # per-patch new-exposure count, written every tick
         model.patches.add_scalar_property("incidence", dtype=np.int32, default=0)
 
+    @property
+    def mixing_matrix(self):
+        """The spatial mixing matrix in use. Shape ``(n_patches, n_patches)``.
+
+        Mirrors the same-named property on the ABM / biweekly InfectionProcess
+        so prompts can use one accessor regardless of model variant.
+        """
+        return self.params.mixer.mixing_matrix
+
     def __call__(self, model: BaseLaserModel, tick: int) -> None:
         # Get state counts: states is (4, num_patches) for [S, E, I, R]
         states = model.patches.states

--- a/src/laser/measles/compartmental/components/process_infection.py
+++ b/src/laser/measles/compartmental/components/process_infection.py
@@ -121,7 +121,7 @@ class InfectionProcess(BaseInfectionProcess):
         model.patches.add_scalar_property("incidence", dtype=np.int32, default=0)
 
     @property
-    def mixing_matrix(self):
+    def mixing_matrix(self) -> np.ndarray:
         """The spatial mixing matrix in use. Shape ``(n_patches, n_patches)``.
 
         Mirrors the same-named property on the ABM / biweekly InfectionProcess

--- a/tests/unit/test_infection_process_mixing_matrix.py
+++ b/tests/unit/test_infection_process_mixing_matrix.py
@@ -1,0 +1,87 @@
+"""Tests for InfectionProcess.mixing_matrix convenience property.
+
+The mixing matrix used by spatial transmission is structurally non-obvious:
+in the ABM variant it lives at
+``InfectionProcess.transmission.params.mixer.mixing_matrix`` (three levels
+deep, and TransmissionProcess isn't registered as a top-level model
+instance). Biweekly and compartmental have it at
+``InfectionProcess.params.mixer.mixing_matrix`` (one level).
+
+The new ``InfectionProcess.mixing_matrix`` property unifies the access
+pattern across all three model variants. These tests verify the property
+returns the same matrix the underlying mixer holds.
+"""
+
+import importlib
+
+import numpy as np
+import polars as pl
+import pytest
+
+from laser.measles.abm import ABMModel
+from laser.measles.abm import ABMParams
+from laser.measles.abm.components import InfectionParams
+from laser.measles.abm.components import InfectionProcess
+from laser.measles.abm.components import InfectionSeedingParams
+from laser.measles.abm.components import InfectionSeedingProcess
+from laser.measles.abm.components import NoBirthsProcess
+from laser.measles.abm.components import StateTracker
+from laser.measles.components import BaseStateTrackerParams
+from laser.measles.components import create_component
+
+
+def _scenario(n_patches: int = 3):
+    return pl.DataFrame(
+        {
+            "id": [f"patch_{i}" for i in range(n_patches)],
+            "lat": [0.0 + i * 0.1 for i in range(n_patches)],
+            "lon": [0.0] * n_patches,
+            "pop": [10_000 * (i + 1) for i in range(n_patches)],
+            "mcv1": [0.0] * n_patches,
+        }
+    )
+
+
+def _build_and_run_abm():
+    params = ABMParams(num_ticks=10, seed=42, start_time="2000-01", show_progress=False)
+    model = ABMModel(_scenario(), params)
+    model.add_component(NoBirthsProcess)
+    model.add_component(create_component(InfectionSeedingProcess, params=InfectionSeedingParams(num_infections=3)))
+    model.add_component(create_component(InfectionProcess, params=InfectionParams()))
+    model.add_component(create_component(StateTracker, params=BaseStateTrackerParams(aggregation_level=0)))
+    model.run()
+    return model
+
+
+def test_abm_infection_process_mixing_matrix_property():
+    model = _build_and_run_abm()
+    ip = model.get_instance("InfectionProcess")[0]
+    mm = ip.mixing_matrix
+
+    # Property returns the same object the deep-path access returns
+    deep = ip.transmission.params.mixer.mixing_matrix
+    assert mm is deep, "mixing_matrix property should be the same object as the deep path"
+
+    # Matrix shape matches patch count
+    n_patches = len(model.scenario)
+    assert mm.shape == (n_patches, n_patches), f"expected ({n_patches}, {n_patches}), got {mm.shape}"
+
+    # Rows sum to ~1 (gravity mixer normalises)
+    np.testing.assert_allclose(mm.sum(axis=1), 1.0, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "laser.measles.compartmental",
+        "laser.measles.biweekly",
+    ],
+)
+def test_compartmental_and_biweekly_have_same_property(module_path):
+    """Both non-ABM variants expose the same `mixing_matrix` property name."""
+    mod = importlib.import_module(module_path)
+    ip_cls = mod.components.InfectionProcess
+    # Property exists on the class
+    assert isinstance(getattr(ip_cls, "mixing_matrix", None), property), (
+        f"{module_path}.InfectionProcess should expose `mixing_matrix` as a property"
+    )


### PR DESCRIPTION
The spatial mixing matrix is structurally hard to reach from a registered component instance in the ABM variant: TransmissionProcess is nested inside InfectionProcess as a sub-component (not registered separately in model.instances), so reaching the matrix takes three hops:

  ip = model.get_instance('InfectionProcess')[0]
  matrix = ip.transmission.params.mixer.mixing_matrix

That's not obvious from dir(ip) and is not documented anywhere prominent. LLMs (and humans) reasonably try .mixing_matrix on the component directly, fail, and either give up or print a confused warning. p14 in the prompt suite hit this consistently.

Add  as a property on InfectionProcess in all three model variants:

  - ABM: walks the deep path (ip.transmission.params.mixer.mixing_matrix)
  - biweekly: ip.params.mixer.mixing_matrix
  - compartmental: ip.params.mixer.mixing_matrix

So now the same pattern works regardless of model type:

  matrix = model.get_instance('InfectionProcess')[0].mixing_matrix

3 tests, all 343 unit tests still pass, lint clean.