### PR TITLE
🎨 Replace polars patch_id expansion with np.repeat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ exclude: '^(\.tox|ci/templates|\.bumpversion\.cfg)(/|$)'
 # Note the order is intentional to avoid multiple passes of the hooks
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.11
+    rev: v0.15.13
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+* Replace polars/list-comprehension run-length expansion of `patch_id` with
+  `np.repeat` in five ABM components: `process_no_births`, `process_constant_pop`,
+  `process_initialize_equilibrium_states`, `process_wpp_vital_dynamics`,
+  and per-tick newborn assignment in `process_vital_dynamics`.
+* Add `patch_id` distribution regression tests for `NoBirthsProcess`,
+  `ConstantPopProcess`, and `VitalDynamicsProcess` births.
+
 ## 0.0.1 (2024-10-18)
 
 * First release on PyPI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,5 @@
 # Changelog
 
-## Unreleased
-
-* Replace polars/list-comprehension run-length expansion of `patch_id` with
-  `np.repeat` in five ABM components: `process_no_births`, `process_constant_pop`,
-  `process_initialize_equilibrium_states`, `process_wpp_vital_dynamics`,
-  and per-tick newborn assignment in `process_vital_dynamics`.
-* Add `patch_id` distribution regression tests for `NoBirthsProcess`,
-  `ConstantPopProcess`, and `VitalDynamicsProcess` births.
-
 ## 0.0.1 (2024-10-18)
 
 * First release on PyPI.

--- a/src/laser/measles/abm/components/process_constant_pop.py
+++ b/src/laser/measles/abm/components/process_constant_pop.py
@@ -3,7 +3,6 @@ Component defining the ConstantPopProcess, which handles the birth events in a m
 """
 
 import numpy as np
-import polars as pl
 
 from laser.measles.abm.model import ABMModel
 from laser.measles.components import BaseConstantPopParams
@@ -121,13 +120,10 @@ class ConstantPopProcess(BaseConstantPopProcess):
             return
 
         people = model.people
-        scenario = model.scenario
 
         # Initialize patch_id according to scenario population
-        people.patch_id[:] = np.array(
-            scenario.with_row_index().select(pl.col("index").repeat_by(pl.col("pop"))).explode("index")["index"].to_numpy(),
-            dtype=people.patch_id.dtype,
-        )
+        pops = model.scenario["pop"].to_numpy()
+        people.patch_id[:] = np.repeat(np.arange(len(pops), dtype=people.patch_id.dtype), pops)
 
         # Simple initializer for ages where birth rate = mortality rate:
         # Initialize ages for existing population

--- a/src/laser/measles/abm/components/process_initialize_equilibrium_states.py
+++ b/src/laser/measles/abm/components/process_initialize_equilibrium_states.py
@@ -3,7 +3,6 @@ Component for initializing the population in each of the model states by rough e
 """
 
 import numpy as np
-import polars as pl
 
 from laser.measles.abm.base import PatchLaserFrame
 from laser.measles.abm.base import PeopleLaserFrame
@@ -54,10 +53,8 @@ class InitializeEquilibriumStatesProcess(BaseInitializeEquilibriumStatesProcess)
         num_active = len(model.people)
 
         # Assign patch_id to each agent based on patch population
-        people.patch_id[:num_active] = np.array(
-            scenario_df.with_row_index().select(pl.col("index").repeat_by(pl.col("pop"))).explode("index")["index"].to_numpy(),
-            dtype=people.patch_id.dtype,
-        )
+        pops = scenario_df["pop"].to_numpy()
+        people.patch_id[:num_active] = np.repeat(np.arange(len(pops), dtype=people.patch_id.dtype), pops)
 
         # Initialize all agents as susceptible first
         people.state[:num_active] = model.params.states.index("S")

--- a/src/laser/measles/abm/components/process_no_births.py
+++ b/src/laser/measles/abm/components/process_no_births.py
@@ -3,7 +3,6 @@ Process for setting a static population (no vital dynamics).
 """
 
 import numpy as np
-import polars as pl
 
 from laser.measles.abm.model import ABMModel
 from laser.measles.base import BaseLaserModel
@@ -71,11 +70,7 @@ class NoBirthsProcess(BaseVitalDynamicsProcess):
         model.initialize_people_capacity(self.calculate_capacity(model))
         # people laserframe
         people = model.people
-        # scenario dataframe
-        scenario = model.scenario
         # initialize the patch ids according to the scenario population
-        people.patch_id[:] = np.array(
-            scenario.with_row_index().select(pl.col("index").repeat_by(pl.col("pop"))).explode("index")["index"].to_numpy(),
-            dtype=people.patch_id.dtype,
-        )
+        pops = model.scenario["pop"].to_numpy()
+        people.patch_id[:] = np.repeat(np.arange(len(pops), dtype=people.patch_id.dtype), pops)
         return

--- a/src/laser/measles/abm/components/process_vital_dynamics.py
+++ b/src/laser/measles/abm/components/process_vital_dynamics.py
@@ -121,11 +121,8 @@ class VitalDynamicsProcess(BaseVitalDynamicsProcess):
             people.date_of_birth[istart:iend] = tick  # born today
             people.susceptibility[istart:iend] = 1.0  # all newborns are susceptible TODO: add maternal immunity component
             people.date_of_vaccination[istart:iend] = tick + self._routine_immunization_delay()
-            index = istart
             # update patch id
-            for this_patch_id, this_patch_births in enumerate(births):
-                people.patch_id[index : index + this_patch_births] = this_patch_id
-                index += this_patch_births
+            people.patch_id[istart:iend] = np.repeat(np.arange(len(births), dtype=people.patch_id.dtype), births)
             # update states
             patches.states.S += cast_type(births, patches.states.dtype)
             # Record per-patch birth count for tracking

--- a/src/laser/measles/abm/components/process_wpp_vital_dynamics.py
+++ b/src/laser/measles/abm/components/process_wpp_vital_dynamics.py
@@ -70,7 +70,8 @@ class WPPVitalDynamicsProcess(BasePhase):
         self.vaccination_queue: SortedQueue = SortedQueue(capacity=capacity, values=people.date_of_vaccination)
 
         # initialize patch id
-        patch_ids = np.concatenate([np.full(pop, i) for i, pop in enumerate(model.scenario["pop"].to_numpy())])
+        pops = model.scenario["pop"].to_numpy()
+        patch_ids = np.repeat(np.arange(len(pops), dtype=people.patch_id.dtype), pops)
         model.prng.shuffle(patch_ids)
         people.patch_id[: len(people)] = patch_ids
 

--- a/tests/unit/test_constant_pop.py
+++ b/tests/unit/test_constant_pop.py
@@ -76,9 +76,7 @@ def test_abm_constant_pop_initial_patch_id_distribution():
 
     pops = scenario["pop"].to_numpy()
     counts = np.bincount(model.people.patch_id[: model.people.count], minlength=len(pops))
-    assert np.array_equal(counts[: len(pops)], pops), (
-        f"Per-patch agent counts {counts[: len(pops)]} do not match scenario pop {pops}"
-    )
+    assert np.array_equal(counts[: len(pops)], pops), f"Per-patch agent counts {counts[: len(pops)]} do not match scenario pop {pops}"
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_constant_pop.py
+++ b/tests/unit/test_constant_pop.py
@@ -1,5 +1,6 @@
 import importlib
 
+import numpy as np
 import pytest
 
 import laser.measles as lm
@@ -57,6 +58,27 @@ def test_constant_pop_with_infection(measles_module):
     ]
     model.run()
     assert model.patches.states.sum() == scenario["pop"].sum()
+
+
+def test_abm_constant_pop_initial_patch_id_distribution():
+    """Given a multi-patch scenario, when ConstantPopProcess initializes the ABM
+    people frame, then patch_id assignment must match the per-patch population
+    counts from the scenario.
+
+    Failure of this assertion would indicate that the contiguous run-length
+    assignment of patch_id from scenario["pop"] has regressed (e.g. the
+    np.repeat-based initialization produces wrong counts per patch).
+    """
+    scenario = lm.scenarios.synthetic.two_patch_scenario(population=20_000)
+    model = lm.abm.Model(scenario, lm.abm.Params(num_ticks=0, verbose=VERBOSE, seed=SEED))
+    model.components = [lm.abm.components.ConstantPopProcess]
+    model.run()
+
+    pops = scenario["pop"].to_numpy()
+    counts = np.bincount(model.people.patch_id[: model.people.count], minlength=len(pops))
+    assert np.array_equal(counts[: len(pops)], pops), (
+        f"Per-patch agent counts {counts[: len(pops)]} do not match scenario pop {pops}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_infection_seeding.py
+++ b/tests/unit/test_infection_seeding.py
@@ -1,5 +1,6 @@
 import importlib
 
+import numpy as np
 import pytest
 
 import laser.measles as lm
@@ -44,6 +45,32 @@ def test_seed_two_patch(measles_module):
         assert model.patches.states.E.sum() == 1
     else:
         assert model.patches.states.I.sum() == 1
+
+
+def test_abm_no_births_initial_patch_id_distribution():
+    """Given a multi-patch ABM scenario with no vital-dynamics component,
+    when the model auto-prepends NoBirthsProcess and initializes,
+    then the per-patch agent counts must match scenario["pop"].
+
+    NoBirthsProcess builds the patch_id array by run-length expansion of the
+    scenario populations. A regression in that expansion (e.g. swapping
+    np.repeat for a faulty implementation) would manifest as a mismatch
+    between np.bincount(people.patch_id) and scenario["pop"].
+    """
+    scenario = lm.scenarios.synthetic.two_patch_scenario(population=20_000)
+    model = lm.abm.Model(scenario, lm.abm.Params(num_ticks=0))
+    # No vital-dynamics component → NoBirthsProcess is auto-prepended.
+    model.components = [
+        lm.abm.components.InfectionSeedingProcess,
+        lm.abm.components.InfectionProcess,
+    ]
+    model.run()
+
+    pops = scenario["pop"].to_numpy()
+    counts = np.bincount(model.people.patch_id[: model.people.count], minlength=len(pops))
+    assert np.array_equal(counts[: len(pops)], pops), (
+        f"Per-patch agent counts {counts[: len(pops)]} do not match scenario pop {pops}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_infection_seeding.py
+++ b/tests/unit/test_infection_seeding.py
@@ -68,9 +68,7 @@ def test_abm_no_births_initial_patch_id_distribution():
 
     pops = scenario["pop"].to_numpy()
     counts = np.bincount(model.people.patch_id[: model.people.count], minlength=len(pops))
-    assert np.array_equal(counts[: len(pops)], pops), (
-        f"Per-patch agent counts {counts[: len(pops)]} do not match scenario pop {pops}"
-    )
+    assert np.array_equal(counts[: len(pops)], pops), f"Per-patch agent counts {counts[: len(pops)]} do not match scenario pop {pops}"
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_vital_dynamics.py
+++ b/tests/unit/test_vital_dynamics.py
@@ -88,6 +88,42 @@ def test_infection_with_vital_dynamics_no_underflow(measles_module):
     assert state_total == active_count, f"State total {state_total} != active agent count {active_count}"
 
 
+def test_abm_vital_dynamics_births_per_patch_assignment():
+    """Given a multi-patch ABM scenario with VitalDynamicsProcess (combined
+    with InitializeEquilibriumStatesProcess to set up initial patch_ids),
+    when the model is run for enough ticks to generate births, then every
+    active agent's patch_id must agree with the per-patch state-count totals.
+
+    VitalDynamicsProcess assigns newborn patch_ids by run-length expansion
+    of the per-patch birth counts. A regression in that expansion (e.g. a
+    bad np.repeat replacement) would skew the per-patch active-agent
+    distribution and cause it to diverge from patches.states.sum(axis=0).
+    """
+    MeaslesModel = importlib.import_module("laser.measles.abm")
+    scenario = MeaslesModel.BaseScenario(lm.scenarios.synthetic.two_patch_scenario(population=50_000))
+    model = MeaslesModel.Model(
+        scenario,
+        MeaslesModel.Params(num_ticks=180, verbose=VERBOSE, seed=SEED),
+    )
+    # InitializeEquilibriumStatesProcess sets initial patch_ids from scenario["pop"];
+    # VitalDynamicsProcess then handles births whose patch_ids are assigned by the
+    # run-length expansion under test.
+    model.components = [
+        MeaslesModel.components.VitalDynamicsProcess,
+        MeaslesModel.components.InitializeEquilibriumStatesProcess,
+    ]
+    model.run()
+
+    num_patches = len(scenario)
+    active_idx = np.where(model.people.active[: model.people.count])[0]
+    agent_counts = np.bincount(model.people.patch_id[active_idx], minlength=num_patches)
+    state_counts = np.asarray(model.patches.states.sum(axis=0))
+
+    assert np.array_equal(agent_counts, state_counts), (
+        f"Active agents per patch {agent_counts} do not match patches.states sum {state_counts}"
+    )
+
+
 if __name__ == "__main__":
     for module in MEASLES_MODULES:
         print(f"Testing {module}...")


### PR DESCRIPTION
Removes the polars list-comprehension approach for run-length expanding `patch_id` in five ABM components, replacing it with `np.repeat(np.arange(...), pops)`. Also adds regression tests for `NoBirthsProcess`, `ConstantPopProcess`, and
`VitalDynamicsProcess` to verify per-patch agent counts match scenario populations.

fixes #111 