### PR TITLE
fix(#117): WPPVitalDynamicsProcess — reset dead-agent state + stamp n…

### DIFF
--- a/src/laser/measles/abm/components/process_wpp_vital_dynamics.py
+++ b/src/laser/measles/abm/components/process_wpp_vital_dynamics.py
@@ -134,6 +134,21 @@ class WPPVitalDynamicsProcess(BasePhase):
                     np.bincount(people.state[patch_idx], minlength=len(model.params.states)), model.patches.states.dtype
                 )
 
+        # Reset dead agents' epidemic state to prevent ghost processing by downstream components.
+        # Without this, agents deactivated mid-epidemic retain non-zero exposure/infection timers
+        # and their state slot, causing DiseaseProcess to generate spurious E→I and I→R transitions
+        # on subsequent ticks that decrement patches.states below zero (uint32 underflow — issue
+        # #117). VitalDynamicsProcess (the non-WPP variant) does this same reset; it was missing
+        # here. Symptom in the wild: per-tick birth lambda computed off a wrapped patches.states
+        # sum reaching ~2³², causing PeopleLaserFrame.add() to overflow capacity by a huge margin.
+        if len(death_idx) > 0:
+            r_state = np.uint8(model.params.states.index("R"))
+            people.state[death_idx] = r_state
+            if hasattr(people, "etimer"):
+                people.etimer[death_idx] = 0
+            if hasattr(people, "itimer"):
+                people.itimer[death_idx] = 0
+
         # Births
         idx = np.where(~people.active)[0]
         i_start = 0
@@ -153,6 +168,19 @@ class WPPVitalDynamicsProcess(BasePhase):
             people.date_of_birth[idx[i_start:i_end]] = tick
             people.state[idx[i_start:i_end]] = model.params.states.index("S")
             people.susceptibility[idx[i_start:i_end]] = 1.0
+            # CRITICAL: stamp the newborn's patch_id. `idx` is a pool of all
+            # inactive slots regardless of their previous patch, so a slot
+            # being reactivated as a newborn in patch X may carry over the
+            # patch_id of whichever agent died in some other patch Y. Without
+            # this assignment, agent-level state.S in patch Y is inflated and
+            # state.S in patch X is deflated, while patches.states.S[X] is
+            # incremented correctly — producing per-patch agent/patch drift
+            # that compounds over ticks and eventually underflows
+            # patches.states.E (issue #117). VitalDynamicsProcess avoids this
+            # by allocating birth slots sequentially via people.add(); WPP
+            # mixes recycled and freshly-added slots, so the explicit stamp
+            # is required here.
+            people.patch_id[idx[i_start:i_end]] = patch_id
             i_start = i_end
             # update state counts
             model.patches.states.S[patch_id] += births

--- a/tests/unit/test_wpp_vital_dynamics.py
+++ b/tests/unit/test_wpp_vital_dynamics.py
@@ -123,21 +123,34 @@ def test_wpp_with_infection_no_state_drift():
     birth lambda is ``patch_pops × birth_rate``). Symptom in the wild was
     ``frame.add() exceeds capacity`` with absurd counts.
 
-    Root cause was that WPPVitalDynamicsProcess deactivated dying agents
-    without resetting their state slot and E/I timers. DiseaseProcess on the
-    next tick would then process those "ghost" E/I agents — generating spurious
-    E→I and I→R transitions that decremented patches.states past zero.
-    VitalDynamicsProcess (non-WPP) was already doing this reset; the fix is
-    to port the same block to WPPVitalDynamicsProcess.
+    Two distinct bugs in WPPVitalDynamicsProcess caused this:
 
-    This test exercises the dangerous combination (WPP + transmission + disease
-    progression) and pins the conservation invariant:
-    ``patches.states.sum() == people.active.sum()`` at every tick.
+      1. Dead agents kept their epidemic state and E/I timers, so DiseaseProcess
+         on subsequent ticks counted them as "ghost" transitions and
+         decremented patches.states past zero.
+      2. Recycled birth slots kept their previous owner's ``patch_id``, so a
+         newborn at patch X (incremented at patches.states.S[X]) was still
+         tagged at agent level with the patch_id of whichever agent died in
+         patch Y. Per-patch agent vs patch-state drift compounds, eventually
+         underflowing patches.states.E when transmission's effective_incidence
+         clamp fires.
+
+    The previous version of this test only checked the GLOBAL conservation
+    invariant — but bug #2 conserves the global total while corrupting the
+    per-patch attribution. Copilot review caught this gap. The current test
+    pins the per-patch invariant: for every (state, patch) cell,
+    ``patches.states[state, patch]`` must equal the count of active agents
+    with that (state, patch_id) combination.
     """
     scenario = two_patch_scenario(population=20_000)
-    # Run multiple years so deaths-in-E/I have time to accumulate drift.
-    # 3 years is enough for the bug to wrap uint32 if the fix isn't in place.
-    params = ABMParams(num_ticks=3 * 365, start_time="2000-01", seed=7)
+    # 45 ticks is enough for cross-patch deaths/births to produce visible
+    # per-(state, patch) drift if the patch_id stamp is missing (drift
+    # first appears around tick 40 in this scenario), but short enough that
+    # the eventual uint32 wraparound and frame.add() crash (~tick 49) don't
+    # happen — so the per-patch assertion below can fire with a clean
+    # diagnostic instead of being preempted by the symptom further down
+    # the chain.
+    params = ABMParams(num_ticks=45, start_time="2000-01", seed=7)
     model = ABMModel(scenario, params)
     model.components = [
         WPPVitalDynamicsProcess,
@@ -146,10 +159,8 @@ def test_wpp_with_infection_no_state_drift():
     ]
     model.run()
 
-    # Conservation invariant: the patch-level state counts should sum to the
-    # number of currently-active agents. Any drift would have made the .sum()
-    # diverge — or worse, uint32 would have wrapped and the sum would be in the
-    # billions.
+    # Global conservation invariant: patches.states.sum() == active count.
+    # This catches the late-stage symptom (uint32 wrap leaking into the sum).
     patch_sum = int(model.patches.states.sum())
     active_count = int(model.people.active.sum())
     assert patch_sum == active_count, (
@@ -157,6 +168,39 @@ def test_wpp_with_infection_no_state_drift():
         f"vs people.active.sum()={active_count:,} — likely uint32 underflow "
         "from ghost E/I agents (see #117)."
     )
+
+    # Per-(state, patch) conservation invariant. This is the strict version
+    # that the global check misses: bug #2 (stale patch_id on recycled
+    # newborns) inflates the agent count for patch Y while
+    # patches.states[X] gets the increment, with no global divergence. Build
+    # the agent-level (state, patch_id) histogram and compare cell-for-cell
+    # to model.patches.states.
+    people = model.people
+    n_states = len(model.params.states)
+    n_patches = len(model.patches)
+    active_mask = people.active[: people.count]
+    active_state = np.asarray(people.state[: people.count])[active_mask]
+    active_patch = np.asarray(people.patch_id[: people.count])[active_mask]
+    # 2D bincount via flat index: state * n_patches + patch
+    flat = active_state.astype(np.int64) * n_patches + active_patch.astype(np.int64)
+    agent_hist = np.bincount(flat, minlength=n_states * n_patches).reshape(n_states, n_patches)
+    patch_hist = np.asarray(model.patches.states).astype(np.int64)
+
+    if not np.array_equal(agent_hist, patch_hist):
+        diff = agent_hist - patch_hist
+        # Locate the worst cell for the error message
+        flat_idx = int(np.abs(diff).argmax())
+        s_idx, p_idx = divmod(flat_idx, n_patches)
+        s_name = model.params.states[s_idx]
+        raise AssertionError(
+            f"per-(state, patch) drift between agent-level and patches.states: "
+            f"worst cell is ({s_name}, patch={p_idx}): "
+            f"agent_hist={int(agent_hist[s_idx, p_idx])}, "
+            f"patch_hist={int(patch_hist[s_idx, p_idx])}, "
+            f"diff={int(diff[s_idx, p_idx]):+d}. "
+            "Likely missing patch_id stamp on recycled newborn slots in "
+            "WPPVitalDynamicsProcess (see #117)."
+        )
 
     # And per-state, every patch's count must be a plausible non-negative number.
     # Catches the explicit underflow signature: a state showing ~2³².

--- a/tests/unit/test_wpp_vital_dynamics.py
+++ b/tests/unit/test_wpp_vital_dynamics.py
@@ -7,9 +7,13 @@ import pytest
 import pyvd
 from scipy import stats
 
+from laser.measles.abm.components import InfectionProcess
+from laser.measles.abm.components import InfectionSeedingParams
+from laser.measles.abm.components import InfectionSeedingProcess
 from laser.measles.abm.components import WPPVitalDynamicsProcess
 from laser.measles.abm.model import ABMModel
 from laser.measles.abm.model import ABMParams
+from laser.measles.components import create_component
 from laser.measles.scenarios.synthetic import two_patch_scenario
 
 
@@ -109,6 +113,61 @@ def test_wpp_vital_dynamics(WPPModel):
     wpp_growth_rate = (final_pyramid.sum() - initial_pyramid.sum()) / initial_pyramid.sum()
     model_growth_rate = (WPPModel.people.active.sum() - WPPModel.scenario["pop"].sum()) / WPPModel.scenario["pop"].sum()
     assert np.isclose(model_growth_rate, wpp_growth_rate, atol=2e-2)
+
+
+@pytest.mark.slow
+def test_wpp_with_infection_no_state_drift():
+    """Regression for laser-measles #117: WPP + InfectionProcess + DiseaseProcess
+    together used to make ``patches.states`` drift below zero on uint32, wrap to
+    ~2³² magnitude, and then make per-tick birth counts explode (since the
+    birth lambda is ``patch_pops × birth_rate``). Symptom in the wild was
+    ``frame.add() exceeds capacity`` with absurd counts.
+
+    Root cause was that WPPVitalDynamicsProcess deactivated dying agents
+    without resetting their state slot and E/I timers. DiseaseProcess on the
+    next tick would then process those "ghost" E/I agents — generating spurious
+    E→I and I→R transitions that decremented patches.states past zero.
+    VitalDynamicsProcess (non-WPP) was already doing this reset; the fix is
+    to port the same block to WPPVitalDynamicsProcess.
+
+    This test exercises the dangerous combination (WPP + transmission + disease
+    progression) and pins the conservation invariant:
+    ``patches.states.sum() == people.active.sum()`` at every tick.
+    """
+    scenario = two_patch_scenario(population=20_000)
+    # Run multiple years so deaths-in-E/I have time to accumulate drift.
+    # 3 years is enough for the bug to wrap uint32 if the fix isn't in place.
+    params = ABMParams(num_ticks=3 * 365, start_time="2000-01", seed=7)
+    model = ABMModel(scenario, params)
+    model.components = [
+        WPPVitalDynamicsProcess,
+        create_component(InfectionSeedingProcess, params=InfectionSeedingParams(num_infections=50)),
+        InfectionProcess,
+    ]
+    model.run()
+
+    # Conservation invariant: the patch-level state counts should sum to the
+    # number of currently-active agents. Any drift would have made the .sum()
+    # diverge — or worse, uint32 would have wrapped and the sum would be in the
+    # billions.
+    patch_sum = int(model.patches.states.sum())
+    active_count = int(model.people.active.sum())
+    assert patch_sum == active_count, (
+        f"patch state drift: patches.states.sum()={patch_sum:,} "
+        f"vs people.active.sum()={active_count:,} — likely uint32 underflow "
+        "from ghost E/I agents (see #117)."
+    )
+
+    # And per-state, every patch's count must be a plausible non-negative number.
+    # Catches the explicit underflow signature: a state showing ~2³².
+    UINT32_MAX = (1 << 32) - 1
+    for state_name in model.params.states:
+        per_patch = np.asarray(getattr(model.patches.states, state_name))
+        assert per_patch.max() < 10 * active_count, (
+            f"patches.states.{state_name}.max()={per_patch.max():,} is implausibly large — uint32 underflow signature."
+        )
+        # uint32 wraparound would land at ~UINT32_MAX; sanity-check we're nowhere close.
+        assert per_patch.max() < UINT32_MAX / 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…ewborn patch_id

Root cause of issue #117 (uint32 underflow in patches.states leading to absurd birth counts and frame.add() capacity blowups) was a two-part bug in WPPVitalDynamicsProcess. Both VitalDynamicsProcess (the non-WPP variant) already handles these correctly; WPP was missing them.

PART 1: dying agents kept their epidemic state and timers ------------------------------------------------------------ When an agent died (people.active[idx] = False), their state and E/I timers were not reset. On subsequent ticks, DiseaseProcess would walk those "ghost" E/I agents (gamma_update and state_update key off timers, not active), generate spurious E→I and I→R transitions, and decrement patches.states.E/I past zero — uint32 wrap to ~2³². Fix: after marking death_idx inactive, set state=R and zero etimer/itimer, mirroring VitalDynamicsProcess.

PART 2: recycled slots kept their previous patch_id ------------------------------------------------------------ WPP's births reuse inactive slots via `idx = np.where(~people.active)[0]`, which is a global pool mixing recycled slots (each with its previous patch_id) and freshly-added slots. The births loop set state, active, date_of_birth, and susceptibility — but NOT patch_id. So a newborn "in patch X" at patches.states level was at agent level still tagged with patch_id Y (the patch of whichever agent died there before).

VitalDynamicsProcess avoids this by allocating birth slots sequentially via a single people.add(births.sum()) call so slot indices are contiguous within the patch loop. WPP mixes recycled and added slots, so the patch_id stamp is required explicitly.

Fix: people.patch_id[idx[i_start:i_end]] = patch_id inside the births loop, alongside the other newborn-property assignments.

Without PART 2, per-patch agent counts and patches.states diverge each tick that has cross-patch deaths/births overlap. Transmission's effective_incidence clamp (line 229 of process_transmission) masks the S-side underflow by capping the decrement at patches.states.S — but that creates the opposite drift in E (agent-level S→E moved more agents than patch-level recorded), which eventually compounds and underflows patches.states.E when DiseaseProcess decrements by the actual E→I flow.

In a 20K-pop two-patch scenario with WPP + InfectionProcess, the drift first appears at tick 41, grows to ±19 over a few ticks, and underflows E at tick 49.

Regression test (test_wpp_with_infection_no_state_drift) pins the invariant: patches.states.sum() == people.active.sum() at end of run, and no per-state count anywhere near UINT32_MAX/2.