### PR TITLE
fix(#215): coerce sia_schedule string dates at SIACalendarParams construction

### DIFF
--- a/src/laser/measles/abm/components/process_sia_calendar.py
+++ b/src/laser/measles/abm/components/process_sia_calendar.py
@@ -10,6 +10,7 @@ from pydantic import model_validator
 from laser.measles.abm.model import ABMModel
 from laser.measles.base import BaseLaserModel
 from laser.measles.base import BasePhase
+from laser.measles.utils import coerce_utf8_date_column
 
 
 class SIACalendarParams(BaseModel):
@@ -26,24 +27,12 @@ class SIACalendarParams(BaseModel):
 
     @model_validator(mode="after")
     def _coerce_sia_schedule_date_column(self) -> "SIACalendarParams":
-        """Auto-cast a string date column on ``sia_schedule`` to polars Datetime.
-
-        When users build the schedule with date strings (e.g.
-        ``[\"2024-06-15\"]``), polars defaults to ``Utf8`` dtype.
-        ``SIACalendarProcess`` later does
-        ``pl.col(date_column) <= model.current_date`` (a ``datetime.date``)
-        and polars rejects the type mismatch with an
-        ``InvalidOperationError`` pointing at framework internals —
-        confusing for the user. See issue #215.
-
-        Detect ``Utf8`` here at construction time and silently cast to
-        ``Datetime``. Leaves already-typed columns alone. Mis-formatted
-        strings will raise a clear ``ValueError`` at this construction
-        step rather than mid-run, which is the desired failure mode.
+        """Silently cast a Utf8 date column on ``sia_schedule`` to ``Datetime``
+        so the per-tick filter in ``SIACalendarProcess.__call__`` doesn't
+        blow up on string-typed user input. Shared logic lives in
+        ``coerce_utf8_date_column``; see laser-measles #215.
         """
-        col = self.date_column
-        if col in self.sia_schedule.columns and self.sia_schedule.schema[col] == pl.Utf8:
-            self.sia_schedule = self.sia_schedule.with_columns(pl.col(col).str.strptime(pl.Datetime, format="%Y-%m-%d").alias(col))
+        self.sia_schedule = coerce_utf8_date_column(self.sia_schedule, self.date_column)
         return self
 
 

--- a/src/laser/measles/abm/components/process_sia_calendar.py
+++ b/src/laser/measles/abm/components/process_sia_calendar.py
@@ -5,6 +5,7 @@ import polars as pl
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import model_validator
 
 from laser.measles.abm.model import ABMModel
 from laser.measles.base import BaseLaserModel
@@ -22,6 +23,28 @@ class SIACalendarParams(BaseModel):
     sia_schedule: pl.DataFrame = Field(description="DataFrame containing SIA schedule information")
     date_column: str = Field("date", description="Name of the column containing SIA dates")
     group_column: str = Field("id", description="Name of the column containing group identifiers")
+
+    @model_validator(mode="after")
+    def _coerce_sia_schedule_date_column(self) -> "SIACalendarParams":
+        """Auto-cast a string date column on ``sia_schedule`` to polars Datetime.
+
+        When users build the schedule with date strings (e.g.
+        ``[\"2024-06-15\"]``), polars defaults to ``Utf8`` dtype.
+        ``SIACalendarProcess`` later does
+        ``pl.col(date_column) <= model.current_date`` (a ``datetime.date``)
+        and polars rejects the type mismatch with an
+        ``InvalidOperationError`` pointing at framework internals —
+        confusing for the user. See issue #215.
+
+        Detect ``Utf8`` here at construction time and silently cast to
+        ``Datetime``. Leaves already-typed columns alone. Mis-formatted
+        strings will raise a clear ``ValueError`` at this construction
+        step rather than mid-run, which is the desired failure mode.
+        """
+        col = self.date_column
+        if col in self.sia_schedule.columns and self.sia_schedule.schema[col] == pl.Utf8:
+            self.sia_schedule = self.sia_schedule.with_columns(pl.col(col).str.strptime(pl.Datetime, format="%Y-%m-%d").alias(col))
+        return self
 
 
 class SIACalendarProcess(BasePhase):

--- a/src/laser/measles/biweekly/components/process_sia_calendar.py
+++ b/src/laser/measles/biweekly/components/process_sia_calendar.py
@@ -9,6 +9,7 @@ from pydantic import model_validator
 from laser.measles.base import BaseLaserModel
 from laser.measles.base import BasePhase
 from laser.measles.utils import cast_type
+from laser.measles.utils import coerce_utf8_date_column
 
 
 class SIACalendarParams(BaseModel):
@@ -25,17 +26,12 @@ class SIACalendarParams(BaseModel):
 
     @model_validator(mode="after")
     def _coerce_sia_schedule_date_column(self) -> "SIACalendarParams":
-        """Auto-cast a string date column on ``sia_schedule`` to polars Datetime.
-
-        Same fix as the ABM SIACalendarParams variant — see issue #215.
-        Users who build the schedule with date strings get a confusing
-        runtime ``InvalidOperationError`` deep in polars; coerce ``Utf8``
-        to ``Datetime`` here at construction time so the failure mode
-        is invisible.
+        """Silently cast a Utf8 date column on ``sia_schedule`` to ``Datetime``
+        so the per-tick filter in ``SIACalendarProcess.__call__`` doesn't
+        blow up on string-typed user input. Shared logic lives in
+        ``coerce_utf8_date_column``; see laser-measles #215.
         """
-        col = self.date_column
-        if col in self.sia_schedule.columns and self.sia_schedule.schema[col] == pl.Utf8:
-            self.sia_schedule = self.sia_schedule.with_columns(pl.col(col).str.strptime(pl.Datetime, format="%Y-%m-%d").alias(col))
+        self.sia_schedule = coerce_utf8_date_column(self.sia_schedule, self.date_column)
         return self
 
 

--- a/src/laser/measles/biweekly/components/process_sia_calendar.py
+++ b/src/laser/measles/biweekly/components/process_sia_calendar.py
@@ -4,6 +4,7 @@ import numpy as np
 import polars as pl
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import model_validator
 
 from laser.measles.base import BaseLaserModel
 from laser.measles.base import BasePhase
@@ -21,6 +22,21 @@ class SIACalendarParams(BaseModel):
     sia_schedule: pl.DataFrame = Field(description="DataFrame containing SIA schedule information")
     date_column: str = Field("date", description="Name of the column containing SIA dates")
     group_column: str = Field("id", description="Name of the column containing group identifiers")
+
+    @model_validator(mode="after")
+    def _coerce_sia_schedule_date_column(self) -> "SIACalendarParams":
+        """Auto-cast a string date column on ``sia_schedule`` to polars Datetime.
+
+        Same fix as the ABM SIACalendarParams variant — see issue #215.
+        Users who build the schedule with date strings get a confusing
+        runtime ``InvalidOperationError`` deep in polars; coerce ``Utf8``
+        to ``Datetime`` here at construction time so the failure mode
+        is invisible.
+        """
+        col = self.date_column
+        if col in self.sia_schedule.columns and self.sia_schedule.schema[col] == pl.Utf8:
+            self.sia_schedule = self.sia_schedule.with_columns(pl.col(col).str.strptime(pl.Datetime, format="%Y-%m-%d").alias(col))
+        return self
 
 
 class SIACalendarProcess(BasePhase):

--- a/src/laser/measles/compartmental/components/process_sia_calendar.py
+++ b/src/laser/measles/compartmental/components/process_sia_calendar.py
@@ -16,6 +16,7 @@ from pydantic import model_validator
 from laser.measles.base import BasePhase
 from laser.measles.compartmental.model import CompartmentalModel
 from laser.measles.utils import cast_type
+from laser.measles.utils import coerce_utf8_date_column
 
 
 class SIACalendarParams(BaseModel):
@@ -32,17 +33,12 @@ class SIACalendarParams(BaseModel):
 
     @model_validator(mode="after")
     def _coerce_sia_schedule_date_column(self) -> "SIACalendarParams":
-        """Auto-cast a string date column on ``sia_schedule`` to polars Datetime.
-
-        Same fix as the ABM SIACalendarParams variant — see issue #215.
-        Users who build the schedule with date strings get a confusing
-        runtime ``InvalidOperationError`` deep in polars; coerce ``Utf8``
-        to ``Datetime`` here at construction time so the failure mode
-        is invisible.
+        """Silently cast a Utf8 date column on ``sia_schedule`` to ``Datetime``
+        so the per-tick filter in ``SIACalendarProcess.__call__`` doesn't
+        blow up on string-typed user input. Shared logic lives in
+        ``coerce_utf8_date_column``; see laser-measles #215.
         """
-        col = self.date_column
-        if col in self.sia_schedule.columns and self.sia_schedule.schema[col] == pl.Utf8:
-            self.sia_schedule = self.sia_schedule.with_columns(pl.col(col).str.strptime(pl.Datetime, format="%Y-%m-%d").alias(col))
+        self.sia_schedule = coerce_utf8_date_column(self.sia_schedule, self.date_column)
         return self
 
 

--- a/src/laser/measles/compartmental/components/process_sia_calendar.py
+++ b/src/laser/measles/compartmental/components/process_sia_calendar.py
@@ -11,6 +11,7 @@ import polars as pl
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import model_validator
 
 from laser.measles.base import BasePhase
 from laser.measles.compartmental.model import CompartmentalModel
@@ -28,6 +29,21 @@ class SIACalendarParams(BaseModel):
     sia_schedule: pl.DataFrame = Field(description="DataFrame containing SIA schedule information")
     date_column: str = Field("date", description="Name of the column containing SIA dates")
     group_column: str = Field("id", description="Name of the column containing group identifiers")
+
+    @model_validator(mode="after")
+    def _coerce_sia_schedule_date_column(self) -> "SIACalendarParams":
+        """Auto-cast a string date column on ``sia_schedule`` to polars Datetime.
+
+        Same fix as the ABM SIACalendarParams variant — see issue #215.
+        Users who build the schedule with date strings get a confusing
+        runtime ``InvalidOperationError`` deep in polars; coerce ``Utf8``
+        to ``Datetime`` here at construction time so the failure mode
+        is invisible.
+        """
+        col = self.date_column
+        if col in self.sia_schedule.columns and self.sia_schedule.schema[col] == pl.Utf8:
+            self.sia_schedule = self.sia_schedule.with_columns(pl.col(col).str.strptime(pl.Datetime, format="%Y-%m-%d").alias(col))
+        return self
 
 
 class SIACalendarProcess(BasePhase):
@@ -83,8 +99,14 @@ class SIACalendarProcess(BasePhase):
         # Store a copy of the original schedule for get_sia_schedule method
         self._original_schedule = self.params.sia_schedule.clone()
 
-        # Convert string dates in SIA schedule to datetime objects for comparison
-        self._convert_schedule_dates()
+        # Empty-schedule type repair: an empty DataFrame whose `date` column
+        # was never written keeps whatever dtype the user gave it (often
+        # `Null`). The SIACalendarParams.@model_validator only fires on
+        # `Utf8` → `Datetime`, so empty-but-not-Utf8 schedules still need
+        # a tiny cast here so the filter works.
+        if len(self.params.sia_schedule) == 0 and self.params.date_column in self.params.sia_schedule.columns:
+            if self.params.sia_schedule.schema[self.params.date_column] != pl.Datetime:
+                self.params.sia_schedule = self.params.sia_schedule.with_columns(pl.col(self.params.date_column).cast(pl.Datetime))
 
         if self.verbose:
             print(f"SIACalendar initialized with {len(self.node_mapping)} groups")
@@ -98,19 +120,6 @@ class SIACalendarProcess(BasePhase):
         required_columns = [self.params.group_column, self.params.date_column]
         if not all(col in self.params.sia_schedule.columns for col in required_columns):
             raise ValueError(f"sia_schedule must contain columns: {required_columns}")
-
-    def _convert_schedule_dates(self) -> None:
-        """Convert string dates in SIA schedule to datetime objects for comparison."""
-        if len(self.params.sia_schedule) == 0:
-            # For empty DataFrames, ensure the date column has the correct type
-            if self.params.date_column in self.params.sia_schedule.columns:
-                self.params.sia_schedule = self.params.sia_schedule.with_columns(pl.col(self.params.date_column).cast(pl.Datetime))
-            return
-
-        # Convert string dates to datetime objects
-        self.params.sia_schedule = self.params.sia_schedule.with_columns(
-            pl.col(self.params.date_column).str.strptime(pl.Datetime, "%Y-%m-%d")
-        )
 
     def _tick_to_date(self, tick: int) -> datetime:
         """Convert tick number to datetime."""

--- a/src/laser/measles/utils.py
+++ b/src/laser/measles/utils.py
@@ -30,6 +30,7 @@ from collections.abc import Callable
 from functools import wraps
 
 import numpy as np
+import polars as pl
 from laser.core.laserframe import LaserFrame
 from laser.core.migration import distance
 
@@ -434,3 +435,34 @@ def dual_implementation(numpy_func: Callable, numba_func: Callable) -> Callable:
     wrapper.numba_func = numba_func
 
     return wrapper
+
+
+def coerce_utf8_date_column(df: "pl.DataFrame", date_column: str) -> "pl.DataFrame":
+    """Cast a ``Utf8`` (string) date column on a polars DataFrame to ``Datetime``.
+
+    Used by ``SIACalendarParams`` validators across all three model variants
+    to silently fix the laser-measles #215 footgun: users build the SIA
+    schedule with date strings (e.g. ``["2024-06-15"]``), polars defaults
+    to ``Utf8``, and the per-tick filter in ``SIACalendarProcess.__call__``
+    later raises an opaque ``InvalidOperationError`` when polars compares
+    the string column to a ``datetime.datetime``.
+
+    Args:
+        df: The polars DataFrame holding the schedule.
+        date_column: Name of the column to coerce.
+
+    Returns:
+        The same DataFrame if the column is missing or already typed; a new
+        DataFrame with the named column cast to ``Datetime`` if it was Utf8.
+        Mis-formatted date strings raise a clear ``ValueError`` from polars
+        at this call rather than at a much later filter site.
+
+    The format pinning (``"%Y-%m-%d"``) is intentional — schedules with
+    non-ISO date strings should fail loud at coercion time rather than
+    being silently misinterpreted.
+    """
+    if date_column in df.columns and df.schema[date_column] == pl.Utf8:
+        return df.with_columns(
+            pl.col(date_column).str.strptime(pl.Datetime, format="%Y-%m-%d").alias(date_column),
+        )
+    return df

--- a/tests/unit/test_sia_calendar.py
+++ b/tests/unit/test_sia_calendar.py
@@ -373,14 +373,14 @@ class TestSIAScheduleDateCoercion:
     which is confusing for the user.
 
     The ``SIACalendarParams.@model_validator`` silently coerces a ``Utf8``
-    date column to ``Date`` at construction time. These tests pin that
+    date column to ``Datetime`` at construction time. These tests pin that
     behaviour: passing string dates results in the model_validator casting
-    them to ``Date`` so the comparison works downstream.
+    them to ``Datetime`` so the comparison works downstream.
     """
 
     def test_string_dates_are_coerced_to_date(self, measles_module):
         """Build sia_schedule with ``date`` as Python strings (Utf8 in polars).
-        After SIACalendarParams construction, the column must be polars Date.
+        After SIACalendarParams construction, the column must be polars Datetime.
         """
         module = importlib.import_module(measles_module)
         schedule = pl.DataFrame(

--- a/tests/unit/test_sia_calendar.py
+++ b/tests/unit/test_sia_calendar.py
@@ -359,3 +359,96 @@ class TestSIACalendarProcess:
         # Should not crash and should not implement any SIAs
         component(model, tick=10)
         assert len(component.implemented_sias) == 0
+
+
+@pytest.mark.parametrize("measles_module", MEASLES_MODULES)
+class TestSIAScheduleDateCoercion:
+    """Regression tests for laser-measles #215.
+
+    Users frequently build the SIA schedule with ``date`` as Python strings
+    (e.g. ``["2024-06-15"]``). Polars defaults string columns to ``Utf8``,
+    and the SIACalendarProcess later compares
+    ``pl.col(date_column) <= model.current_date`` — polars rejects the type
+    mismatch with an ``InvalidOperationError`` deep in framework internals,
+    which is confusing for the user.
+
+    The ``SIACalendarParams.@model_validator`` silently coerces a ``Utf8``
+    date column to ``Date`` at construction time. These tests pin that
+    behaviour: passing string dates results in the model_validator casting
+    them to ``Date`` so the comparison works downstream.
+    """
+
+    def test_string_dates_are_coerced_to_date(self, measles_module):
+        """Build sia_schedule with ``date`` as Python strings (Utf8 in polars).
+        After SIACalendarParams construction, the column must be polars Date.
+        """
+        module = importlib.import_module(measles_module)
+        schedule = pl.DataFrame(
+            {
+                "id": ["NG:KN", "NG:KD"],
+                "date": ["2023-01-10", "2023-01-15"],  # left as strings on purpose
+            }
+        )
+        assert schedule.schema["date"] == pl.Utf8, "fixture sanity: starting dtype should be Utf8"
+        params = module.components.SIACalendarParams(sia_schedule=schedule)
+        assert params.sia_schedule.schema["date"] == pl.Datetime, (
+            f"SIACalendarParams should coerce Utf8 date column to Datetime, got {params.sia_schedule.schema['date']}"
+        )
+
+    def test_already_typed_column_is_preserved(self, measles_module):
+        """If the user already passed a properly-typed date column, the
+        validator must NOT touch it (no spurious re-cast). The framework
+        compares against ``datetime.datetime`` internally, so Datetime is
+        the canonical pre-typed dtype here."""
+        module = importlib.import_module(measles_module)
+        schedule = pl.DataFrame(
+            {
+                "id": ["NG:KN", "NG:KD"],
+                "date": ["2023-01-10", "2023-01-15"],
+            }
+        ).with_columns(pl.col("date").str.strptime(pl.Datetime, format="%Y-%m-%d"))
+        assert schedule.schema["date"] == pl.Datetime
+
+        params = module.components.SIACalendarParams(sia_schedule=schedule)
+        assert params.sia_schedule.schema["date"] == pl.Datetime
+
+    def test_custom_date_column_name_is_honored(self, measles_module):
+        """The coercion targets ``date_column``, not a hard-coded ``date``."""
+        module = importlib.import_module(measles_module)
+        schedule = pl.DataFrame(
+            {
+                "id": ["NG:KN", "NG:KD"],
+                "schedule_date": ["2023-01-10", "2023-01-15"],  # Utf8
+            }
+        )
+        params = module.components.SIACalendarParams(
+            sia_schedule=schedule,
+            date_column="schedule_date",
+        )
+        assert params.sia_schedule.schema["schedule_date"] == pl.Datetime
+
+    def test_string_dates_drive_a_run_without_crashing(self, mock_scenario, measles_module):
+        """End-to-end smoke: build params from a string-date schedule and
+        run a few ticks. The comparison inside SIACalendarProcess.__call__
+        used to raise InvalidOperationError; with the validator it does not.
+        """
+        module = importlib.import_module(measles_module)
+        schedule = pl.DataFrame(
+            {
+                "id": ["NG:KN", "NG:KD"],
+                "date": ["2023-01-10", "2023-01-15"],  # Utf8 — the bug trigger
+            }
+        )
+        params = module.components.SIACalendarParams(sia_schedule=schedule, aggregation_level=2)
+        model = setup_sia_sim(
+            mock_scenario,
+            create_model_params(module),
+            params,
+            module,
+        )
+        # 30 ticks is past the second SIA date in the schedule; the
+        # comparison runs every tick. If the date column were still Utf8
+        # we'd get InvalidOperationError at tick 1.
+        for tick in range(30):
+            component = next(p for p in model.phases if type(p).__name__ == "SIACalendarProcess")
+            component(model, tick=tick)


### PR DESCRIPTION
When users build an SIA schedule with date strings (e.g. ``["2024-06-15"]``), polars defaults the column to Utf8. SIACalendarProcess then does ``pl.col(date_column) <= model.current_date`` (a datetime.datetime in all three variants) and polars raises an InvalidOperationError pointing at framework internals — confusing for the user. This was the most common LLM-codegen failure mode in the jenner-measles-mcp prompt suite.

Per the issue's recommended "combined approach", apply silent validation-time coercion in addition to the existing docs gotcha:

  - Add ``@model_validator(mode="after")`` to SIACalendarParams in all three variants (abm / biweekly / compartmental).
  - On Utf8 date columns, cast to ``Datetime`` via ``pl.col(date_column).str.strptime(pl.Datetime, format="%Y-%m-%d")``.
  - Properly-typed columns are left untouched. Mis-formatted strings will raise a clear ValueError at construction time rather than at mid-run, which is the desired failure mode.

Compartmental had its own runtime ``_convert_schedule_dates`` that called ``str.strptime`` unconditionally. With the validator running first, that runtime cast now clashes with an already-Datetime column. Replace it with a small "empty-schedule type repair" block that only fires for empty DataFrames whose date column dtype is something other than Datetime (e.g. ``Null``) — the validator doesn't fire on those since the column isn't Utf8.

Regression test ``TestSIAScheduleDateCoercion`` (12 cases across three variants) covers:
  - Utf8 dates are coerced to Datetime by SIACalendarParams construction
  - Already-typed columns are left alone (no spurious re-cast)
  - Custom ``date_column`` names are honored, not hard-coded "date"
  - End-to-end: a string-date schedule drives a real run for 30 ticks without InvalidOperationError

Verified by temporarily disabling the validator (commenting out the ``@model_validator`` line): the first regression test fails with "got String", which is exactly the contract the validator is supposed to enforce.

All 63 SIA tests pass (51 existing + 12 new).