### PR TITLE
Fix 248: InfectionParams.mixer kwarg forwards to TransmissionParams

### DIFF
--- a/src/laser/measles/abm/components/process_infection.py
+++ b/src/laser/measles/abm/components/process_infection.py
@@ -2,6 +2,8 @@
 Component defining the InfectionProcess, which orchestrates the transmission and disease progression of measles in a population.
 """
 
+from typing import Any
+
 import numpy as np
 from matplotlib.figure import Figure
 from pydantic import Field
@@ -21,31 +23,34 @@ from .process_transmission import TransmissionProcess
 class InfectionParams(BaseInfectionParams):
     """Combined parameters for ABM transmission and disease processes.
 
-    Spatial mixing strength is controlled via ``distance_exponent`` and
-    ``mixing_scale``, which configure the default
-    :class:`~laser.measles.mixing.gravity.GravityMixing` model used
-    internally. The model sets the patch scenario on the mixer automatically
-    at initialisation.
+    Spatial mixing is controlled in one of two ways:
 
-    .. note::
+    1. **Default gravity** — leave ``mixer`` as ``None`` and configure
+       ``distance_exponent`` and ``mixing_scale``. Internally a
+       :class:`~laser.measles.mixing.gravity.GravityMixing` is constructed
+       using those values.
+    2. **Custom mixer** — pass any mixing object (e.g. ``GravityMixing(...)``,
+       ``RadiationMixing(...)``) as ``mixer=``. When set, this takes
+       precedence; ``distance_exponent`` and ``mixing_scale`` are ignored.
 
-        Unlike the compartmental :class:`InfectionParams
-        <laser.measles.compartmental.components.process_infection.InfectionParams>`,
-        this class does not currently accept a ``mixer=`` argument. To use
-        a custom mixing model or non-default gravity parameters, configure
-        ``distance_exponent`` and ``mixing_scale`` here, or construct a
-        :class:`~laser.measles.abm.components.process_transmission.TransmissionProcess`
-        directly with a custom
-        :class:`~laser.measles.abm.components.process_transmission.TransmissionParams`.
+    The model sets the patch scenario on the mixer automatically at
+    initialisation, so callers don't need to assign ``mixer.scenario``
+    themselves.
 
-    Example::
+    Examples::
 
-        # Control gravity mixing decay and scale via InfectionParams
+        # 1. Default gravity, tuned via the convenience knobs
         infection_params = InfectionParams(
             beta=20.0,
-            seasonality=0.0,
-            distance_exponent=2.0,  # stronger distance decay
-            mixing_scale=0.005,     # lower overall mixing rate
+            distance_exponent=2.0,
+            mixing_scale=0.005,
+        )
+
+        # 2. Custom mixer — e.g. radiation model
+        from laser.measles.mixing.radiation import RadiationMixing
+        infection_params = InfectionParams(
+            beta=20.0,
+            mixer=RadiationMixing(),
         )
     """
 
@@ -56,23 +61,38 @@ class InfectionParams(BaseInfectionParams):
     exp_sigma: float = Field(default=2.0, description="Exposure sigma (lognormal)", gt=0.0)
     inf_mean: float = Field(default=8.0, description="Mean infection duration", gt=0.0)
     inf_sigma: float = Field(default=2.0, description="Shape parameter for infection duration", gt=0.0)
-    distance_exponent: float = Field(default=1.5, description="Distance exponent", ge=0.0)
-    mixing_scale: float = Field(default=0.001, description="Mixing scale", ge=0.0)
+    distance_exponent: float = Field(default=1.5, description="Distance exponent (used only when mixer is None)", ge=0.0)
+    mixing_scale: float = Field(default=0.001, description="Mixing scale (used only when mixer is None)", ge=0.0)
+    mixer: Any | None = Field(
+        default=None,
+        description="Optional custom mixing object (GravityMixing, RadiationMixing, ...). When set, distance_exponent and mixing_scale are ignored.",
+    )
 
     @property
     def transmission_params(self) -> TransmissionParams:
-        """Extract transmission-specific parameters.
+        """Build the TransmissionParams to hand to TransmissionProcess.
 
-        Wires user-facing ``distance_exponent`` and ``mixing_scale`` into the
-        default ``GravityMixing`` instance.
+        If the caller supplied a ``mixer``, pass it through. Otherwise wire
+        ``distance_exponent`` and ``mixing_scale`` into a default
+        ``GravityMixing(GravityParams(c=..., k=...))``. The latter is the
+        fix called out in #140 — passing those values to TransmissionParams
+        directly silently dropped them because TransmissionParams doesn't
+        declare them.
         """
+        mixer = (
+            self.mixer
+            if self.mixer is not None
+            else GravityMixing(
+                params=GravityParams(c=self.distance_exponent, k=self.mixing_scale),
+            )
+        )
         return TransmissionParams(
             beta=self.beta,
             seasonality=self.seasonality,
             season_start=self.season_start,
             exp_mu=self.exp_mu,
             exp_sigma=self.exp_sigma,
-            mixer=GravityMixing(params=GravityParams(c=self.distance_exponent, k=self.mixing_scale)),
+            mixer=mixer,
         )
 
     @property

--- a/tests/unit/test_infection_params_mixer.py
+++ b/tests/unit/test_infection_params_mixer.py
@@ -1,0 +1,65 @@
+"""Tests for the `mixer=` field on the ABM `InfectionParams`.
+
+Previously the ABM `InfectionParams` had no `mixer` field — passing
+``mixer=`` was silently accepted (pre-#140) or rejected (post-#140) but
+either way did nothing. Users needed to construct a TransmissionParams
+manually or monkey-patch after model.components=. This file locks in the
+new behaviour:
+
+  - `InfectionParams(mixer=X)` puts X into `transmission_params.mixer`.
+  - When `mixer` is not set, `transmission_params.mixer` is a
+    `GravityMixing` configured from `distance_exponent` and
+    `mixing_scale` (the #140 fix path).
+"""
+
+import pytest
+
+from laser.measles.abm.components import InfectionParams
+from laser.measles.mixing.gravity import GravityMixing
+from laser.measles.mixing.gravity import GravityParams
+
+
+def test_default_mixer_is_gravity_using_distance_exponent_and_mixing_scale():
+    p = InfectionParams(beta=1.0, distance_exponent=3.5, mixing_scale=0.07)
+    tp = p.transmission_params
+
+    assert isinstance(tp.mixer, GravityMixing)
+    # GravityMixing was built with params=GravityParams(c=3.5, k=0.07)
+    assert tp.mixer.params.c == 3.5
+    assert tp.mixer.params.k == 0.07
+
+
+def test_explicit_mixer_overrides_distance_exponent_and_mixing_scale():
+    # User passes a fully-configured mixer; distance_exponent / mixing_scale
+    # should be ignored.
+    custom = GravityMixing(params=GravityParams(c=42.0, k=0.42))
+    p = InfectionParams(beta=1.0, distance_exponent=3.5, mixing_scale=0.07, mixer=custom)
+    tp = p.transmission_params
+
+    assert tp.mixer is custom
+    assert tp.mixer.params.c == 42.0
+    assert tp.mixer.params.k == 0.42
+
+
+def test_custom_mixer_class_accepted_via_mixer_kwarg():
+    # The fix's reason for being: a non-gravity mixer (e.g. RadiationMixing)
+    # must be acceptable as the InfectionParams `mixer=` value, not only
+    # GravityMixing. Skip the test if RadiationMixing isn't importable;
+    # the existing GravityMixing-based tests above still cover the
+    # field-level wiring.
+    radiation_module = pytest.importorskip("laser.measles.mixing.radiation")
+    mixer = radiation_module.RadiationMixing()
+
+    p = InfectionParams(beta=1.0, mixer=mixer)
+    tp = p.transmission_params
+
+    assert tp.mixer is mixer
+
+
+def test_mixer_defaults_to_none_on_construction():
+    p = InfectionParams(beta=1.0)
+    assert p.mixer is None
+    # The property still produces a usable TransmissionParams with a
+    # GravityMixing default.
+    tp = p.transmission_params
+    assert isinstance(tp.mixer, GravityMixing)

--- a/tests/unit/test_transmission.py
+++ b/tests/unit/test_transmission.py
@@ -52,7 +52,10 @@ class ChainTransmissionProcess(lm.base.BaseComponent):
         assert len(c) == 1, "There should be exactly one infection process"
         assert c[0].initialized, "Infection process must be initialized"
         num_patches = len(model.scenario)
-        if hasattr(c[0].params, "mixer"):
+        # ABM InfectionParams now has a `mixer` field that defaults to None
+        # (the actual mixer lives on TransmissionParams in that case), so we
+        # check for a non-None value rather than just the attribute's presence.
+        if getattr(c[0].params, "mixer", None) is not None:
             c[0].params.mixer._mixing_matrix = np.diag(np.ones(num_patches - 1), k=1)
         elif hasattr(c[0], "transmission"):
             c[0].transmission.params.mixer._mixing_matrix = np.diag(np.ones(num_patches - 1), k=1)


### PR DESCRIPTION
ABM InfectionParams previously had no `mixer` field. Users who tried to configure a non-default mixer with InfectionParams(mixer=RadiationMixing()) hit one of two failure modes depending on pydantic config:

  - extra='ignore' (legacy default): silently dropped — the simulation used the default GravityMixing regardless of what was passed.
  - extra='forbid' (the fix on fix/params-no-silent-ignore): noisy ValidationError with no clear way forward in the docs.

This is the same shape as issue #140 (distance_exponent / mixing_scale silently dropped when forwarded to TransmissionParams). Solution mirrors

  - Add `mixer: Any | None = Field(default=None, ...)` on InfectionParams.
  - InfectionParams.transmission_params now constructs the TransmissionParams mixer field from one of two sources:
      * if user passed mixer=X explicitly → use X
      * else → GravityMixing(GravityParams(c=distance_exponent, k=mixing_scale))
  - distance_exponent and mixing_scale stop being passed to TransmissionParams as direct fields (they never were declared there); they now properly drive the default GravityMixing.

Docstring updated with both usage patterns. Test `test_infection_params_mixer.py` locks in the contract (4 cases: default gravity uses distance_exponent/ mixing_scale; explicit mixer overrides them; non-gravity mixer accepted; field defaults to None).

Also touches `tests/unit/test_transmission.py`: ChainTransmissionProcess dispatched on `hasattr(params, 'mixer')` to pick between params- and transmission-level mixer. Now params.mixer exists (defaulting to None), so the test must check for a non-None value to keep selecting the transmission-level mixer when no explicit one is configured.