### PR TITLE
⬆️ use laser-core 1.0.2 or newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "laser-core~=1.0",
+  "laser-core>=1.0.2,<2.0",
   "diskcache~=5.0",
   "appdirs~=1.4",
   "pydantic~=2.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "laser-core>=1.0.1",
+  "laser-core>=1.0.2,<2.0",
   "diskcache>=5.0",
   "appdirs>=1.4.4",
   "pydantic>=2.12.5",


### PR DESCRIPTION
1.0.2 significantly reduces the cost to import KaplanMeierEstimator which is ~70% of the import time (when warm) of the perf script in Kano measles

laser-core==1.0.1 ... import time for `perf_script.py` - 13.8s
laser-core==1.0.2 ... import time for `perf_script.py` - 4.0s

fixes #81 