### PR TITLE
docs(PopulationTracker): show post-run data access in docstrings

### DIFF
--- a/src/laser/measles/abm/components/tracker_population.py
+++ b/src/laser/measles/abm/components/tracker_population.py
@@ -5,6 +5,10 @@ from laser.measles.components import BasePopulationTrackerParams
 class PopulationTracker(BasePopulationTracker):
     """Tracks the population size of each patch at each time tick.
 
+    The recorded series lives on ``tracker.population_tracker`` (shape
+    ``(n_patches, n_ticks)``) after ``model.run()``. Sum across the patch
+    axis for the global population time series.
+
     **Example:**
 
         ```python
@@ -17,6 +21,13 @@ class PopulationTracker(BasePopulationTracker):
         params = ABMParams(num_ticks=365, seed=42, start_time="2000-01")
         model = ABMModel(scenario, params)
         model.add_component(create_component(components.PopulationTracker, components.PopulationTrackerParams()))
+        model.run()
+
+        # Read the recorded time series after the run.
+        tracker = model.get_instance("PopulationTracker")[0]
+        pop_per_patch = tracker.population_tracker     # shape (n_patches, n_ticks)
+        pop_global = pop_per_patch.sum(axis=0)         # shape (n_ticks,)
+        print(f"start: {pop_global[0]:,}, end: {pop_global[-1]:,}")
         ```
     """
 

--- a/src/laser/measles/biweekly/components/tracker_population.py
+++ b/src/laser/measles/biweekly/components/tracker_population.py
@@ -3,7 +3,11 @@ from laser.measles.components import BasePopulationTrackerParams
 
 
 class PopulationTracker(BasePopulationTracker):
-    """Tracks the population size of each patch.
+    """Tracks the population size of each patch at each time tick.
+
+    The recorded series lives on ``tracker.population_tracker`` (shape
+    ``(n_patches, n_ticks)``) after ``model.run()``. Sum across the patch
+    axis for the global population time series.
 
     **Example:**
 
@@ -17,6 +21,13 @@ class PopulationTracker(BasePopulationTracker):
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.add_component(create_component(components.PopulationTracker, components.PopulationTrackerParams()))
+        model.run()
+
+        # Read the recorded time series after the run.
+        tracker = model.get_instance("PopulationTracker")[0]
+        pop_per_patch = tracker.population_tracker     # shape (n_patches, n_ticks)
+        pop_global = pop_per_patch.sum(axis=0)         # shape (n_ticks,)
+        print(f"start: {pop_global[0]:,}, end: {pop_global[-1]:,}")
         ```
     """
 

--- a/src/laser/measles/compartmental/components/tracker_population.py
+++ b/src/laser/measles/compartmental/components/tracker_population.py
@@ -3,7 +3,11 @@ from laser.measles.components import BasePopulationTrackerParams
 
 
 class PopulationTracker(BasePopulationTracker):
-    """Tracks the population size of each patch.
+    """Tracks the population size of each patch at each time tick.
+
+    The recorded series lives on ``tracker.population_tracker`` (shape
+    ``(n_patches, n_ticks)``) after ``model.run()``. Sum across the patch
+    axis for the global population time series.
 
     **Example:**
 
@@ -17,6 +21,13 @@ class PopulationTracker(BasePopulationTracker):
         params = CompartmentalParams(num_ticks=365, seed=42, start_time="2000-01")
         model = CompartmentalModel(scenario, params)
         model.add_component(create_component(components.PopulationTracker, components.PopulationTrackerParams()))
+        model.run()
+
+        # Read the recorded time series after the run.
+        tracker = model.get_instance("PopulationTracker")[0]
+        pop_per_patch = tracker.population_tracker     # shape (n_patches, n_ticks)
+        pop_global = pop_per_patch.sum(axis=0)         # shape (n_ticks,)
+        print(f"start: {pop_global[0]:,}, end: {pop_global[-1]:,}")
         ```
     """
 

--- a/src/laser/measles/components/base_tracker_population.py
+++ b/src/laser/measles/components/base_tracker_population.py
@@ -11,8 +11,18 @@ class BasePopulationTrackerParams(BaseModel):
 
 
 class BasePopulationTracker(BasePhase):
-    """
-    Tracks the population size of each patch at each time tick.
+    """Tracks the population size of each patch at each time tick.
+
+    After ``model.run()``, the recorded time series is available as a numpy
+    array on the ``population_tracker`` attribute:
+
+        ``tracker.population_tracker`` — shape ``(n_patches, n_ticks)``, the
+        total agent count per patch at each tick. Sum across the patch axis
+        (``axis=0``) to get the global population time series.
+
+    Subclasses for ABM, biweekly, and compartmental models share this layout;
+    see their docstrings for end-to-end examples that include the post-run
+    access pattern.
     """
 
     def __init__(self, model: BaseLaserModel, params: BasePopulationTrackerParams | None = None) -> None:


### PR DESCRIPTION
Fixes #253.

The existing docstrings demonstrated how to add PopulationTracker as a component but stopped before model.run(), leaving the reader (or an LLM consuming the docs) to guess where the recorded series lives. p19 of the jenner-mcp prompt suite reliably failed because the generated code tried introspecting common attribute names (population, pop, N, total_population, history) and missed the actual one (population_tracker), even though it was visible in __dict__.

Extend the example to include model.run() and the model.get_instance()
+ tracker.population_tracker read pattern, and document the array layout ((n_patches, n_ticks)) on the base class so future subclasses inherit the contract.