### PR TITLE
Fix docstrings

### DIFF
--- a/docs/customization/gen-files.py
+++ b/docs/customization/gen-files.py
@@ -121,11 +121,11 @@ def _render_tree(root: str, tree: dict) -> list[str]:
 
     def walk(rel_parts: list[str], node: dict):
         # rel_parts is the path under the root (e.g., ['generic', 'models'])
-        dotted = ".".join([root, *rel_parts])
         depth = len(rel_parts)  # depth under the root
         indent = "  " * depth  # bullet indent under the root line we'll add earlier
         path = "/".join([root.replace(".", "/"), *rel_parts]) + "/index.md"
-        lines.append(f"{indent}- [{dotted}]({path})\n")
+        label = rel_parts[-1]  # leaf segment only, so deep names aren't truncated in the nav
+        lines.append(f"{indent}- [{label}]({path})\n")
         for seg in sorted(node.keys()):
             walk([*rel_parts, seg], node[seg])
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ markdown_extensions:
   - md_in_html # enables grids
   - admonition # warnings, etc.
   - def_list
+  - tables # render Markdown pipe tables
   - pymdownx.emoji: # emojis and icons
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
@@ -136,7 +137,10 @@ plugins:
             show_symbol_type_heading: true
             show_symbol_type_toc: true
             show_root_toc_entry: true
-            show_object_full_path: true
+            show_object_full_path: false
+            show_root_full_path: false
+            docstring_options:
+              trim_doctest_flags: true
   - exclude:
       glob:
         - customization/gen-files.py # exclude file generation script

--- a/src/laser/measles/abm/base.py
+++ b/src/laser/measles/abm/base.py
@@ -16,14 +16,12 @@ class PeopleLaserFrame(BasePeopleLaserFrame):
     Laserframe for people (e.g., agent) properties
 
 
-    **Example:**
+    Examples:
 
-        ```python
         # ABM people LaserFrame tracks individual agents
         model.people.state     # health state per agent
         model.people.age       # age in days per agent
         model.people.patch_id  # patch assignment per agent
-        ```
     """
 
     patch_id: np.ndarray
@@ -39,12 +37,10 @@ class PatchLaserFrame(BasePatchLaserFrame):
     storage and access patterns specific to agent-based models.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         model.patches.S  # susceptible counts, shape (nticks+1, num_patches)
         model.patches.I  # infectious counts
-        ```
     """
 
 
@@ -53,14 +49,12 @@ class BaseABMScenarioSchema(pt.Model):
     Schema for the scenario data.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
 
         scenario = single_patch_scenario(population=50_000, mcv1_coverage=0.85)
         # Validated automatically when passed to ABMModel(scenario, params)
-        ```
     """
 
     pop: int  # population
@@ -82,13 +76,11 @@ class BaseABMScenario(LaserMeaslesBaseScenario):
         df: Polars DataFrame with patch-level data.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
 
         scenario = single_patch_scenario(population=50_000, mcv1_coverage=0.85)
-        ```
     """
 
     def __init__(self, df: pl.DataFrame):

--- a/src/laser/measles/abm/components/process_constant_pop.py
+++ b/src/laser/measles/abm/components/process_constant_pop.py
@@ -13,13 +13,11 @@ from laser.measles.utils import cast_type
 class ConstantPopParams(BaseConstantPopParams):
     """Parameters for constant-population vital dynamics (inherits all fields from base).
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.abm.components.process_constant_pop import ConstantPopParams
 
         params = ConstantPopParams(crude_birth_rate=20)
-        ```
     """
 
 
@@ -28,15 +26,13 @@ class ConstantPopProcess(BaseConstantPopProcess):
     A component to handle the birth events in a model with constant population - that is, births == deaths.
 
     Attributes:
-
         model: The model instance containing population and parameters.
         initializers (list): List of initializers to be called on birth events.
         metrics (DataFrame): DataFrame to holding timing metrics for initializers.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.abm import ABMModel, ABMParams
         from laser.measles.abm import components
@@ -46,7 +42,6 @@ class ConstantPopProcess(BaseConstantPopProcess):
         params = ABMParams(num_ticks=365, seed=42, start_time="2000-01")
         model = ABMModel(scenario, params)
         model.add_component(create_component(components.ConstantPopProcess, components.ConstantPopParams(crude_birth_rate=20)))
-        ```
     """
 
     def __init__(self, model: ABMModel, params: ConstantPopParams | None = None):
@@ -54,7 +49,6 @@ class ConstantPopProcess(BaseConstantPopProcess):
         Initialize the Births component.
 
         Parameters:
-
             model (object): The model object which must have a `population` attribute.
             params (BirthsParams, optional): Component parameters. If None, uses model.params.
 
@@ -86,17 +80,15 @@ class ConstantPopProcess(BaseConstantPopProcess):
         Adds new agents to each patch based on expected daily births calculated from CBR. Calls each of the registered initializers for the newborns.
 
         Args:
-
             model: The simulation model containing patches, population, and parameters.
             tick: The current time step in the simulation.
 
         Returns:
-
             None
 
         This method performs the following steps:
 
-            1. Draw a random set of indices, or size size "number of births"  from the population,
+        1. Draw a random set of indices, or size size "number of births"  from the population,
         """
 
         if self.lambda_birth == 0:

--- a/src/laser/measles/abm/components/process_importation.py
+++ b/src/laser/measles/abm/components/process_importation.py
@@ -26,13 +26,11 @@ from ..utils import seed_infections_randomly
 class ImportationParams(BaseModel):
     """Parameters specific to the importation process components.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.abm.components.process_importation import ImportationParams
 
         params = ImportationParams()
-        ```
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -50,9 +48,8 @@ class InfectRandomAgentsProcess:
     A component to update the infection timers of a population in a model.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.abm import ABMModel, ABMParams
         from laser.measles.abm import components
@@ -62,7 +59,6 @@ class InfectRandomAgentsProcess:
         params = ABMParams(num_ticks=365, seed=42, start_time="2000-01")
         model = ABMModel(scenario, params)
         model.add_component(create_component(components.InfectRandomAgentsProcess, components.ImportationParams()))
-        ```
     """
 
     def __init__(self, model: ABMModel, params: ImportationParams | None = None) -> None:
@@ -79,7 +75,6 @@ class InfectRandomAgentsProcess:
                 the values are loaded from ``model.params`` for backward compatibility.
 
         Attributes:
-
             model: The model object that contains the population.
 
         Side Effects:
@@ -110,12 +105,10 @@ class InfectRandomAgentsProcess:
         Updates the infection timers for the population in the model.
 
         Args:
-
             model: The model containing the population data.
             tick: The current tick or time step in the simulation.
 
         Returns:
-
             None
         """
         if (tick >= self.start) and ((tick - self.start) % self.period == 0) and (tick < self.end):
@@ -140,9 +133,8 @@ class InfectAgentsInPatchProcess:
     A component to update the infection timers of a population in a model.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.abm import ABMModel, ABMParams
         from laser.measles.abm import components
@@ -152,7 +144,6 @@ class InfectAgentsInPatchProcess:
         params = ABMParams(num_ticks=365, seed=42, start_time="2000-01")
         model = ABMModel(scenario, params)
         model.add_component(create_component(components.InfectAgentsInPatchProcess, components.ImportationParams()))
-        ```
     """
 
     def __init__(self, model: ABMModel, params: ImportationParams | None = None) -> None:
@@ -171,7 +162,6 @@ class InfectAgentsInPatchProcess:
                 ``model.params`` for backward compatibility.
 
         Attributes:
-
             model: The model object that contains the population.
 
         Side Effects:
@@ -204,12 +194,10 @@ class InfectAgentsInPatchProcess:
         Updates the infection timers for the population in the model.
 
         Args:
-
             model: The model containing the population data.
             tick: The current tick or time step in the simulation.
 
         Returns:
-
             None
         """
         if (tick >= self.start) and ((tick - self.start) % self.period == 0) and (tick < self.end):

--- a/src/laser/measles/abm/components/process_importation_pressure.py
+++ b/src/laser/measles/abm/components/process_importation_pressure.py
@@ -51,50 +51,64 @@ class ImportationPressureParams(BaseModel):
             greater than ``importation_start`` when not ``-1``.
 
     Examples:
-        Uniform low background pressure across all patches::
+        Uniform low background pressure across all patches:
 
-            params = ImportationPressureParams(crude_importation_rate=0.05)
+        ```python
+        params = ImportationPressureParams(crude_importation_rate=0.05)
+        ```
 
-        Disable importation entirely::
+        Disable importation entirely:
 
-            params = ImportationPressureParams(crude_importation_rate=0.0)
+        ```python
+        params = ImportationPressureParams(crude_importation_rate=0.0)
+        ```
 
-        Per-patch sequence (one entry per patch, aligned to scenario row order)::
+        Per-patch sequence (one entry per patch, aligned to scenario row order):
 
-            # 25-patch model; patch at row index 12 is the metro hub
-            rates = [0.02] * 25
-            rates[12] = 0.5
-            params = ImportationPressureParams(crude_importation_rate=rates)
+        ```python
+        # 25-patch model; patch at row index 12 is the metro hub
+        rates = [0.02] * 25
+        rates[12] = 0.5
+        params = ImportationPressureParams(crude_importation_rate=rates)
+        ```
 
-        Sparse dict — only named patches receive importation; all others get 0.0::
+        Sparse dict — only named patches receive importation; all others get 0.0:
 
-            # Use string ids from model.scenario["id"], e.g. "n_0_0", "n_2_2"
-            params = ImportationPressureParams(
-                crude_importation_rate={"n_2_2": 0.5, "n_0_0": 0.1},
-            )
+        ```python
+        # Use string ids from model.scenario["id"], e.g. "n_0_0", "n_2_2"
+        params = ImportationPressureParams(
+            crude_importation_rate={"n_2_2": 0.5, "n_0_0": 0.1},
+        )
+        ```
 
-        Numpy array input (accepted and converted to list internally)::
+        Numpy array input (accepted and converted to list internally):
 
-            import numpy as np
-            params = ImportationPressureParams(
-                crude_importation_rate=np.array([0.01, 0.05, 0.01, 0.01, 0.01])
-            )
+        ```python
+        import numpy as np
+        params = ImportationPressureParams(
+            crude_importation_rate=np.array([0.01, 0.05, 0.01, 0.01, 0.01])
+        )
+        ```
 
-        Time-windowed importation active only during the first year (days 0-364)::
+        Time-windowed importation active only during the first year (days 0-364):
 
-            params = ImportationPressureParams(
-                crude_importation_rate=0.1,
-                importation_start=0,
-                importation_end=364,
-            )
+        ```python
+        params = ImportationPressureParams(
+            crude_importation_rate=0.1,
+            importation_start=0,
+            importation_end=364,
+        )
+        ```
 
-        Metro-only importation for the first year, then stop::
+        Metro-only importation for the first year, then stop:
 
-            params = ImportationPressureParams(
-                crude_importation_rate={"n_2_2": 2.0},
-                importation_start=0,
-                importation_end=364,
-            )
+        ```python
+        params = ImportationPressureParams(
+            crude_importation_rate={"n_2_2": 2.0},
+            importation_start=0,
+            importation_end=364,
+        )
+        ```
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -163,23 +177,18 @@ class ImportationPressureProcess(BasePhase):
     - Time-windowed importation (start/end times)
     - Population updates: Moves individuals from susceptible to infected state
 
-    Parameters
-    ----------
-    model : object
-        The simulation model containing nodes, states, and parameters
-    params : Optional[ImportationPressureParams], default=None
-        Component-specific parameters. If None, will use default parameters
+    Args:
+        model (object): The simulation model containing nodes, states, and parameters
+        params (Optional[ImportationPressureParams], default=None): Component-specific parameters. If None, will use default parameters
 
-    Notes
-    -----
-    - Importation rates are calculated per year
-    - Importation is limited to the susceptible population
-    - All state counts are ensured to be non-negative
+    Notes:
+        - Importation rates are calculated per year
+        - Importation is limited to the susceptible population
+        - All state counts are ensured to be non-negative
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.abm import ABMModel, ABMParams
         from laser.measles.abm import components
@@ -189,7 +198,6 @@ class ImportationPressureProcess(BasePhase):
         params = ABMParams(num_ticks=365, seed=42, start_time="2000-01")
         model = ABMModel(scenario, params)
         model.add_component(create_component(components.ImportationPressureProcess, components.ImportationPressureParams()))
-        ```
     """
 
     def __init__(self, model, params: ImportationPressureParams | None = None) -> None:

--- a/src/laser/measles/abm/components/process_infection.py
+++ b/src/laser/measles/abm/components/process_infection.py
@@ -28,7 +28,7 @@ class InfectionParams(BaseInfectionParams):
 
     1. **Default gravity** — leave ``mixer`` as ``None`` and configure
        ``distance_exponent`` and ``mixing_scale``. Internally a
-       :class:`~laser.measles.mixing.gravity.GravityMixing` is constructed
+       [`GravityMixing`][laser.measles.mixing.gravity.GravityMixing] is constructed
        using those values.
     2. **Custom mixer** — pass any mixing object (e.g. ``GravityMixing(...)``,
        ``RadiationMixing(...)``) as ``mixer=``. When set, this takes
@@ -38,7 +38,7 @@ class InfectionParams(BaseInfectionParams):
     initialisation, so callers don't need to assign ``mixer.scenario``
     themselves.
 
-    Examples::
+    Examples:
 
         # 1. Default gravity, tuned via the convenience knobs
         infection_params = InfectionParams(
@@ -122,9 +122,8 @@ class InfectionProcess(BaseInfectionProcess):
     but for agent-based modeling.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.abm import ABMModel, ABMParams
         from laser.measles.abm import components
@@ -134,7 +133,6 @@ class InfectionProcess(BaseInfectionProcess):
         params = ABMParams(num_ticks=365, seed=42, start_time="2000-01")
         model = ABMModel(scenario, params)
         model.add_component(create_component(components.InfectionProcess, components.InfectionParams(beta=0.3)))
-        ```
     """
 
     def __init__(self, model: ABMModel, params: InfectionParams | None = None) -> None:

--- a/src/laser/measles/abm/components/process_infection_seeding.py
+++ b/src/laser/measles/abm/components/process_infection_seeding.py
@@ -21,13 +21,11 @@ from laser.measles.base import BaseLaserModel
 class InfectionSeedingParams(BaseModel):
     """Parameters for the infection seeding component.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.abm.components.process_infection_seeding import InfectionSeedingParams
 
         params = InfectionSeedingParams()
-        ```
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -96,26 +94,25 @@ class InfectionSeedingProcess(BaseComponent):
         model: The compartmental model instance.
         params: Component-specific parameters. If None, uses default parameters.
 
-    Example:
-        .. code-block:: python
+    Examples:
 
-            # Seed 1 infection in largest patch (default)
-            seeding_params = InfectionSeedingParams()
+        # Seed 1 infection in largest patch (default)
+        seeding_params = InfectionSeedingParams()
 
-            # Seed 5 infections in largest patch
-            seeding_params = InfectionSeedingParams(num_infections=5)
+        # Seed 5 infections in largest patch
+        seeding_params = InfectionSeedingParams(num_infections=5)
 
-            # Seed specific patches with same number of infections
-            seeding_params = InfectionSeedingParams(
-                target_patches=["nigeria:kano:kano:A0001", "nigeria:kano:kano:A0002"],
-                infections_per_patch=3,
-            )
+        # Seed specific patches with same number of infections
+        seeding_params = InfectionSeedingParams(
+            target_patches=["nigeria:kano:kano:A0001", "nigeria:kano:kano:A0002"],
+            infections_per_patch=3,
+        )
 
-            # Seed specific patches with different numbers of infections
-            seeding_params = InfectionSeedingParams(
-                target_patches=["nigeria:kano:kano:A0001", "nigeria:kano:kano:A0002"],
-                infections_per_patch=[5, 2],
-            )
+        # Seed specific patches with different numbers of infections
+        seeding_params = InfectionSeedingParams(
+            target_patches=["nigeria:kano:kano:A0001", "nigeria:kano:kano:A0002"],
+            infections_per_patch=[5, 2],
+        )
     """
 
     def __init__(self, model: BaseLaserModel, params: InfectionSeedingParams | None = None) -> None:

--- a/src/laser/measles/abm/components/process_initialize_equilibrium_states.py
+++ b/src/laser/measles/abm/components/process_initialize_equilibrium_states.py
@@ -16,13 +16,11 @@ class InitializeEquilibriumStatesParams(BaseInitializeEquilibriumStatesParams):
     Parameters for the InitializeEquilibriumStatesProcess.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.abm.components.process_initialize_equilibrium_states import InitializeEquilibriumStatesParams
 
         params = InitializeEquilibriumStatesParams()
-        ```
     """
 
 
@@ -34,9 +32,8 @@ class InitializeEquilibriumStatesProcess(BaseInitializeEquilibriumStatesProcess)
     and individual agent initialization consistent with those counts.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.abm import ABMModel, ABMParams
         from laser.measles.abm import components
@@ -46,7 +43,6 @@ class InitializeEquilibriumStatesProcess(BaseInitializeEquilibriumStatesProcess)
         params = ABMParams(num_ticks=365, seed=42, start_time="2000-01")
         model = ABMModel(scenario, params)
         model.add_component(create_component(components.InitializeEquilibriumStatesProcess, components.InitializeEquilibriumStatesParams()))
-        ```
     """
 
     def _initialize(self, model: ABMModel) -> None:

--- a/src/laser/measles/abm/components/process_no_births.py
+++ b/src/laser/measles/abm/components/process_no_births.py
@@ -13,13 +13,11 @@ from laser.measles.components import BaseVitalDynamicsProcess
 class NoBirthsParams(BaseVitalDynamicsParams):
     """Parameters for the no births process.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.abm.components.process_no_births import NoBirthsParams
 
         params = NoBirthsParams()
-        ```
     """
 
     @property
@@ -38,9 +36,8 @@ class NoBirthsProcess(BaseVitalDynamicsProcess):
     Component for setting the population of the patches to not have births.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.abm import ABMModel, ABMParams
         from laser.measles.abm import components
@@ -50,7 +47,6 @@ class NoBirthsProcess(BaseVitalDynamicsProcess):
         params = ABMParams(num_ticks=365, seed=42, start_time="2000-01")
         model = ABMModel(scenario, params)
         model.add_component(create_component(components.NoBirthsProcess, components.NoBirthsParams()))
-        ```
     """
 
     def __init__(

--- a/src/laser/measles/abm/components/process_sia_calendar.py
+++ b/src/laser/measles/abm/components/process_sia_calendar.py
@@ -16,13 +16,11 @@ from laser.measles.utils import coerce_utf8_date_column
 class SIACalendarParams(BaseModel):
     """Parameters specific to the SIA calendar component.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.abm.components.process_sia_calendar import SIACalendarParams
 
         params = SIACalendarParams()
-        ```
     """
 
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
@@ -55,26 +53,21 @@ class SIACalendarProcess(BasePhase):
     3. Uses the model's current_date to determine when to implement SIAs
     4. Applies vaccination with configurable efficacy rate to individual agents
 
-    Parameters
-    ----------
-    model : ABMModel
-        The ABM simulation model containing agents, patches, and parameters
-    params : Optional[SIACalendarParams], default=None
-        Component-specific parameters. If None, will use default parameters
+    Args:
+        model (ABMModel): The ABM simulation model containing agents, patches, and parameters
+        params (Optional[SIACalendarParams], default=None): Component-specific parameters. If None, will use default parameters
 
-    Notes
-    -----
-    - SIA efficacy determines the fraction of susceptibles that get vaccinated
-    - Individual agents are randomly selected for vaccination based on efficacy
-    - SIAs are implemented when the model's current_date has passed the scheduled date
-    - Vaccination moves agents from susceptible (S=0) to recovered (R=3) state
-    - Both individual agent states and patch-level state aggregations are updated
-    - Each SIA is implemented exactly once
+    Notes:
+        - SIA efficacy determines the fraction of susceptibles that get vaccinated
+        - Individual agents are randomly selected for vaccination based on efficacy
+        - SIAs are implemented when the model's current_date has passed the scheduled date
+        - Vaccination moves agents from susceptible (S=0) to recovered (R=3) state
+        - Both individual agent states and patch-level state aggregations are updated
+        - Each SIA is implemented exactly once
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.abm import ABMModel, ABMParams
         from laser.measles.abm import components
@@ -84,7 +77,6 @@ class SIACalendarProcess(BasePhase):
         params = ABMParams(num_ticks=365, seed=42, start_time="2000-01")
         model = ABMModel(scenario, params)
         model.add_component(create_component(components.SIACalendarProcess, components.SIACalendarParams()))
-        ```
     """
 
     def __init__(self, model: ABMModel, params: SIACalendarParams | None = None) -> None:
@@ -203,11 +195,9 @@ class SIACalendarProcess(BasePhase):
         """
         Get the SIA schedule.
 
-        Returns
-        -------
-        pl.DataFrame
-            DataFrame with columns:
-            - {group_column}: Group identifier
-            - {date_column}: Scheduled date for SIA
+        Returns:
+            pl.DataFrame: DataFrame with columns:
+                - {group_column}: Group identifier
+                - {date_column}: Scheduled date for SIA
         """
         return self.params.sia_schedule

--- a/src/laser/measles/abm/components/process_transmission.py
+++ b/src/laser/measles/abm/components/process_transmission.py
@@ -107,13 +107,11 @@ else:
 class TransmissionParams(BaseModel):
     """Parameters specific to the transmission process component.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.abm.components.process_transmission import TransmissionParams
 
         params = TransmissionParams(beta=0.3)
-        ```
     """
 
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
@@ -141,9 +139,8 @@ class TransmissionProcess(BasePhase):
     A component to model the transmission of disease in a population.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.abm import ABMModel, ABMParams
         from laser.measles.abm import components
@@ -153,7 +150,6 @@ class TransmissionProcess(BasePhase):
         params = ABMParams(num_ticks=365, seed=42, start_time="2000-01")
         model = ABMModel(scenario, params)
         model.add_component(create_component(components.TransmissionProcess, components.TransmissionParams(beta=0.3)))
-        ```
     """
 
     def __init__(self, model, params: TransmissionParams | None = None) -> None:
@@ -161,20 +157,18 @@ class TransmissionProcess(BasePhase):
         Initializes the transmission object.
 
         Args:
-
             model: The model object that contains the patches and parameters.
 
         Attributes:
-
             model: The model object passed during initialization.
 
         The model's patches are extended with the following scalar property:
 
-            - 'incidence' (uint32, per patch): number of *new* infections
-              during the most recent tick; overwritten each tick. For
-              cumulative incidence over a run, sum this each tick yourself,
-              or compute from per-tick decreases in ``S`` recorded by a
-              StateTracker.
+        - 'incidence' (uint32, per patch): number of *new* infections
+          during the most recent tick; overwritten each tick. For
+          cumulative incidence over a run, sum this each tick yourself,
+          or compute from per-tick decreases in ``S`` recorded by a
+          StateTracker.
         """
 
         super().__init__(model)
@@ -205,12 +199,10 @@ class TransmissionProcess(BasePhase):
         updates the infected state of the population.
 
         Parameters:
-
             model (object): The model object containing the population, patches, and parameters.
             tick (int): The current time step in the simulation.
 
         Returns:
-
             None
 
         """

--- a/src/laser/measles/abm/components/process_vital_dynamics.py
+++ b/src/laser/measles/abm/components/process_vital_dynamics.py
@@ -17,13 +17,11 @@ class VitalDynamicsParams(BaseVitalDynamicsParams):
     Parameters for VitalDynamicsProcess.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.abm.components.process_vital_dynamics import VitalDynamicsParams
 
         params = VitalDynamicsParams()
-        ```
     """
 
     routine_immunization_delay: int = Field(default=9 * 30, description="Delay in days before routine immunization is administered")
@@ -34,9 +32,8 @@ class VitalDynamicsProcess(BaseVitalDynamicsProcess):
     Process for simulating vital dynamics in the ABM model with MCV1 and constant birth and mortality rates (not age-structured).
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.abm import ABMModel, ABMParams
         from laser.measles.abm import components
@@ -46,7 +43,6 @@ class VitalDynamicsProcess(BaseVitalDynamicsProcess):
         params = ABMParams(num_ticks=365, seed=42, start_time="2000-01")
         model = ABMModel(scenario, params)
         model.add_component(create_component(components.VitalDynamicsProcess, components.VitalDynamicsParams()))
-        ```
     """
 
     def __init__(self, model, params: VitalDynamicsParams | None = None) -> None:

--- a/src/laser/measles/abm/components/tracker_case_surveillance.py
+++ b/src/laser/measles/abm/components/tracker_case_surveillance.py
@@ -5,22 +5,19 @@ from laser.measles.components import BaseCaseSurveillanceTracker
 class CaseSurveillanceParams(BaseCaseSurveillanceParams):
     """Parameters for CaseSurveillanceParams (inherits all fields from base).
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.abm.components.tracker_case_surveillance import CaseSurveillanceParams
 
         params = CaseSurveillanceParams()
-        ```
     """
 
 
 class CaseSurveillanceTracker(BaseCaseSurveillanceTracker):
     """Case surveillance tracker for this model type.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.abm import ABMModel, ABMParams
         from laser.measles.abm import components
@@ -30,7 +27,6 @@ class CaseSurveillanceTracker(BaseCaseSurveillanceTracker):
         params = ABMParams(num_ticks=365, seed=42, start_time="2000-01")
         model = ABMModel(scenario, params)
         model.add_component(create_component(components.CaseSurveillanceTracker, components.CaseSurveillanceParams()))
-        ```
     """
 
 

--- a/src/laser/measles/abm/components/tracker_fadeout.py
+++ b/src/laser/measles/abm/components/tracker_fadeout.py
@@ -5,9 +5,8 @@ from laser.measles.components import BaseFadeOutTrackerParams
 class FadeOutTracker(BaseFadeOutTracker):
     """A component that tracks the number of nodes experiencing fade-outs over time.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.abm import ABMModel, ABMParams
         from laser.measles.abm import components
@@ -17,18 +16,15 @@ class FadeOutTracker(BaseFadeOutTracker):
         params = ABMParams(num_ticks=365, seed=42, start_time="2000-01")
         model = ABMModel(scenario, params)
         model.add_component(create_component(components.FadeOutTracker, components.FadeOutTrackerParams()))
-        ```
     """
 
 
 class FadeOutTrackerParams(BaseFadeOutTrackerParams):
     """Parameters for the FadeOutTracker component.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.abm.components.tracker_fadeout import FadeOutTrackerParams
 
         params = FadeOutTrackerParams()
-        ```
     """

--- a/src/laser/measles/abm/components/tracker_population.py
+++ b/src/laser/measles/abm/components/tracker_population.py
@@ -9,9 +9,8 @@ class PopulationTracker(BasePopulationTracker):
     ``(n_patches, n_ticks)``) after ``model.run()``. Sum across the patch
     axis for the global population time series.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.abm import ABMModel, ABMParams
         from laser.measles.abm import components
@@ -28,18 +27,15 @@ class PopulationTracker(BasePopulationTracker):
         pop_per_patch = tracker.population_tracker     # shape (n_patches, n_ticks)
         pop_global = pop_per_patch.sum(axis=0)         # shape (n_ticks,)
         print(f"start: {pop_global[0]:,}, end: {pop_global[-1]:,}")
-        ```
     """
 
 
 class PopulationTrackerParams(BasePopulationTrackerParams):
     """Parameters for PopulationTrackerParams (inherits all fields from base).
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.abm.components.tracker_population import PopulationTrackerParams
 
         params = PopulationTrackerParams()
-        ```
     """

--- a/src/laser/measles/abm/components/tracker_state.py
+++ b/src/laser/measles/abm/components/tracker_state.py
@@ -10,13 +10,11 @@ class StateTrackerParams(BaseStateTrackerParams):
     ABM-specific defaults and validation.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.abm.components.tracker_state import StateTrackerParams
 
         params = StateTrackerParams()
-        ```
     """
 
 
@@ -29,9 +27,8 @@ class StateTracker(BaseStateTracker):
     at the patch level.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.abm import ABMModel, ABMParams
         from laser.measles.abm import components
@@ -41,5 +38,4 @@ class StateTracker(BaseStateTracker):
         params = ABMParams(num_ticks=365, seed=42, start_time="2000-01")
         model = ABMModel(scenario, params)
         model.add_component(create_component(components.StateTracker, components.StateTrackerParams()))
-        ```
     """

--- a/src/laser/measles/abm/model.py
+++ b/src/laser/measles/abm/model.py
@@ -168,7 +168,7 @@ class ABMModel(BaseLaserModel):
 
         Parameters:
             fig (Figure, optional): A matplotlib Figure object to use for plotting. If None, a new figure will be created.
-        
+
         Yields:
             None: This function uses a generator to yield control back to the caller after each plot is created.
 

--- a/src/laser/measles/abm/model.py
+++ b/src/laser/measles/abm/model.py
@@ -224,19 +224,16 @@ class ABMModel(BaseLaserModel):
                 ready for ``model.run()``.
 
         Examples:
-            This is my code.
 
-        ```python
-        import laser.measles as lm
+            import laser.measles as lm
 
-        params2 = lm.ABMParams(num_ticks=1825, seed=42, start_time="2009-12")
-        model2 = lm.ABMModel.from_snapshot(
-            "checkpoint.h5",
-            params2,
-            components=[lm.VitalDynamicsProcess, lm.InfectionProcess],
-        )
-        model2.run()
-        ```
+            params2 = lm.ABMParams(num_ticks=1825, seed=42, start_time="2009-12")
+            model2 = lm.ABMModel.from_snapshot(
+                "checkpoint.h5",
+                params2,
+                components=[lm.VitalDynamicsProcess, lm.InfectionProcess],
+            )
+            model2.run()
         """
         from laser.measles.abm.snapshot import load_snapshot  # noqa: PLC0415
 

--- a/src/laser/measles/abm/model.py
+++ b/src/laser/measles/abm/model.py
@@ -46,9 +46,8 @@ class ABMModel(BaseLaserModel):
             ``seed``, and ``start_time``.  This argument is **mandatory**.
         name (str): Display name for log messages.  Defaults to ``"abm"``.
 
-    **Example:**
+    Examples:
 
-        ```python
         import laser.measles as lm
 
         params = lm.ABMParams(num_ticks=365, seed=42, start_time="2000-01")
@@ -56,7 +55,6 @@ class ABMModel(BaseLaserModel):
         model.add_component(lm.InfectionSeedingProcess)
         model.add_component(lm.InfectionProcess)
         model.run()
-        ```
     """
 
     people: PeopleLaserFrame
@@ -169,18 +167,16 @@ class ABMModel(BaseLaserModel):
         Plots various visualizations related to the scenario and population data.
 
         Parameters:
-
             fig (Figure, optional): A matplotlib Figure object to use for plotting. If None, a new figure will be created.
-
+        
         Yields:
-
             None: This function uses a generator to yield control back to the caller after each plot is created.
 
         The function generates three plots:
 
-            1. A scatter plot of the scenario patches and populations.
-            2. A histogram of the distribution of the day of birth for the initial population.
-            3. A pie chart showing the distribution of update phase times.
+        1. A scatter plot of the scenario patches and populations.
+        2. A histogram of the distribution of the day of birth for the initial population.
+        3. A pie chart showing the distribution of update phase times.
         """
 
         _fig = plt.figure(figsize=(12, 9), dpi=128) if fig is None else fig
@@ -227,19 +223,20 @@ class ABMModel(BaseLaserModel):
             A configured [`ABMModel`][laser.measles.abm.model.ABMModel]
                 ready for ``model.run()``.
 
-        **Example:**
+        Examples:
+            This is my code.
 
-            ```python
-            import laser.measles as lm
+        ```python
+        import laser.measles as lm
 
-            params2 = lm.ABMParams(num_ticks=1825, seed=42, start_time="2009-12")
-            model2 = lm.ABMModel.from_snapshot(
-                "checkpoint.h5",
-                params2,
-                components=[lm.VitalDynamicsProcess, lm.InfectionProcess],
-            )
-            model2.run()
-            ```
+        params2 = lm.ABMParams(num_ticks=1825, seed=42, start_time="2009-12")
+        model2 = lm.ABMModel.from_snapshot(
+            "checkpoint.h5",
+            params2,
+            components=[lm.VitalDynamicsProcess, lm.InfectionProcess],
+        )
+        model2.run()
+        ```
         """
         from laser.measles.abm.snapshot import load_snapshot  # noqa: PLC0415
 

--- a/src/laser/measles/abm/params.py
+++ b/src/laser/measles/abm/params.py
@@ -25,11 +25,9 @@ class ABMParams(BaseModelParams):
             Default: ``"2000-01"``.
         verbose: Print detailed logging.  Default: ``False``.
 
-    **Example:**
+    Examples:
 
-        ```python
         params = ABMParams(num_ticks=365, seed=42, start_time="2000-01")
-        ```
     """
 
     @property

--- a/src/laser/measles/abm/snapshot.py
+++ b/src/laser/measles/abm/snapshot.py
@@ -6,21 +6,19 @@ and allow the simulation to be resumed exactly from that point.
 
 Typical usage:
 
-```python
-import laser.measles as lm
+    import laser.measles as lm
 
-# --- Segment 1 ---
-model1 = lm.ABMModel(scenario, params1)
-model1.components = [lm.VitalDynamicsProcess, lm.InfectionProcess]
-model1.run()
-lm.save_snapshot(model1, "checkpoint.h5")
+    # --- Segment 1 ---
+    model1 = lm.ABMModel(scenario, params1)
+    model1.components = [lm.VitalDynamicsProcess, lm.InfectionProcess]
+    model1.run()
+    lm.save_snapshot(model1, "checkpoint.h5")
 
-# --- Segment 2 ---
-params2 = lm.ABMParams(start_time="2001-01", num_ticks=365)
-model2 = lm.load_snapshot("checkpoint.h5", params2,
-                           components=[lm.VitalDynamicsProcess, lm.InfectionProcess])
-model2.run()
-```
+    # --- Segment 2 ---
+    params2 = lm.ABMParams(start_time="2001-01", num_ticks=365)
+    model2 = lm.load_snapshot("checkpoint.h5", params2,
+                               components=[lm.VitalDynamicsProcess, lm.InfectionProcess])
+    model2.run()
 
 Notes:
     - ``save_snapshot`` **modifies** the model in place: R agents are squashed and

--- a/src/laser/measles/abm/snapshot.py
+++ b/src/laser/measles/abm/snapshot.py
@@ -4,21 +4,23 @@ Snapshot save/load for the laser-measles ABM.
 Snapshots capture the full population and patch state at a given point in time
 and allow the simulation to be resumed exactly from that point.
 
-Typical usage::
+Typical usage:
 
-    import laser.measles as lm
+```python
+import laser.measles as lm
 
-    # --- Segment 1 ---
-    model1 = lm.ABMModel(scenario, params1)
-    model1.components = [lm.VitalDynamicsProcess, lm.InfectionProcess]
-    model1.run()
-    lm.save_snapshot(model1, "checkpoint.h5")
+# --- Segment 1 ---
+model1 = lm.ABMModel(scenario, params1)
+model1.components = [lm.VitalDynamicsProcess, lm.InfectionProcess]
+model1.run()
+lm.save_snapshot(model1, "checkpoint.h5")
 
-    # --- Segment 2 ---
-    params2 = lm.ABMParams(start_time="2001-01", num_ticks=365)
-    model2 = lm.load_snapshot("checkpoint.h5", params2,
-                               components=[lm.VitalDynamicsProcess, lm.InfectionProcess])
-    model2.run()
+# --- Segment 2 ---
+params2 = lm.ABMParams(start_time="2001-01", num_ticks=365)
+model2 = lm.load_snapshot("checkpoint.h5", params2,
+                           components=[lm.VitalDynamicsProcess, lm.InfectionProcess])
+model2.run()
+```
 
 Notes:
     - ``save_snapshot`` **modifies** the model in place: R agents are squashed and
@@ -78,9 +80,8 @@ def save_snapshot(
             measles runs.
         verbose: Print a progress summary.
 
-    **Example:**
+    Examples:
 
-        ```python
         import laser.measles as lm
 
         params = lm.ABMParams(num_ticks=3650, seed=42, start_time="2000-01")
@@ -90,7 +91,6 @@ def save_snapshot(
 
         lm.save_snapshot(model, "checkpoint.h5")
         # Do not use model after this point.
-        ```
     """
     path = Path(path)
 
@@ -211,9 +211,8 @@ def load_snapshot(
         A configured [`ABMModel`][laser.measles.abm.model.ABMModel] instance.
             Call ``model.run()`` to continue the simulation.
 
-    **Example:**
+    Examples:
 
-        ```python
         import laser.measles as lm
 
         params2 = lm.ABMParams(num_ticks=1825, seed=42, start_time="2009-12")
@@ -223,7 +222,6 @@ def load_snapshot(
             components=[lm.VitalDynamicsProcess, lm.InfectionProcess],
         )
         model2.run()
-        ```
     """
     from laser.measles.abm.base import PeopleLaserFrame  # noqa: PLC0415
     from laser.measles.abm.model import ABMModel  # noqa: PLC0415

--- a/src/laser/measles/abm/utils.py
+++ b/src/laser/measles/abm/utils.py
@@ -30,17 +30,14 @@ def calc_distances(latitudes: np.ndarray, longitudes: np.ndarray, verbose: bool 
     Calculate the pairwise distances between points given their latitudes and longitudes.
 
     Parameters:
-
         latitudes (np.ndarray): A 1-dimensional array of latitudes.
         longitudes (np.ndarray): A 1-dimensional array of longitudes with the same shape as latitudes.
         verbose (bool, optional): If True, prints the upper left corner of the distance matrix. Default is False.
 
     Returns:
-
         np.ndarray: A 2-dimensional array where the element at [i, j] represents the distance between the i-th and j-th points.
 
     Raises:
-
         AssertionError: If latitudes is not 1-dimensional or if latitudes and longitudes do not have the same shape.
     """
 
@@ -62,14 +59,12 @@ def calc_capacity(population: np.uint32, nticks: np.uint32, cbr: np.float32, ver
     Calculate the population capacity after a given number of ticks based on a constant birth rate (CBR).
 
     Args:
-
         population (np.uint32): The initial population.
         nticks (np.uint32): The number of ticks (time steps) to simulate.
         cbr (np.float32): The constant birth rate per 1000 people per year.
         verbose (bool, optional): If True, prints detailed population growth information. Defaults to False.
 
     Returns:
-
         np.uint32: The estimated population capacity after the given number of ticks.
     """
 
@@ -101,13 +96,11 @@ def seed_infections_randomly_SI(model, ninfections: int = 100) -> None:
     them with an infection, based on the specified number of initial infections.
 
     Args:
-
         model: The simulation model containing the population and parameters.
         ninfections (int, optional): The number of initial infections to seed.
                                      Defaults to 100.
 
     Returns:
-
         None
     """
 
@@ -129,13 +122,11 @@ def seed_infections_randomly(model, ninfections: int = 100) -> np.ndarray:
     them with an infection, based on the specified number of initial infections.
 
     Args:
-
         model: The simulation model containing the population and parameters.
         ninfections (int, optional): The number of initial infections to seed.
                                      Defaults to 100.
 
     Returns:
-
         np.ndarray: The nodeids of the individuals seeded with an infection.
     """
 
@@ -158,13 +149,11 @@ def seed_infections_in_patch(model, ipatch: int, ninfections: int = 1) -> None:
     the desired number of initial infections is reached.
 
     Args:
-
         model: The simulation model containing the population and parameters.
         ipatch (int): The identifier of the patch where infections should be seeded.
         ninfections (int, optional): The number of initial infections to seed. Defaults to 100.
 
     Returns:
-
         None
     """
 
@@ -185,13 +174,11 @@ def set_initial_susceptibility_in_patch(model, ipatch: int, susc_frac: float = 1
     their susceptibility to zero, according to the parameter susc_frac.
 
     Args:
-
         model: The simulation model containing the population and parameters.
         ipatch: The patch to set susceptibility in
         susc_frac (float, optional): The fraction of individuals to keep susceptible.
 
     Returns:
-
         None
     """
 
@@ -210,12 +197,10 @@ def set_initial_susceptibility_randomly(model, susc_frac: float = 1.0) -> None:
     their susceptibility to zero, according to the parameter susc_frac.
 
     Args:
-
         model: The simulation model containing the population and parameters.
         susc_frac (float, optional): The fraction of individuals to keep susceptible.
 
     Returns:
-
         None
     """
 

--- a/src/laser/measles/base.py
+++ b/src/laser/measles/base.py
@@ -783,8 +783,8 @@ class BaseComponent:
 
         Examples:
 
-            >>> # In a component's __init__ or _initialize method:
-            >>> self.update_func = self.select_function(numpy_update, numba_update)
+            # In a component's __init__ or _initialize method:
+            self.update_func = self.select_function(numpy_update, numba_update)
         """
         # Check if model has use_numba parameter
         use_numba = getattr(self.model.params, "use_numba", True)

--- a/src/laser/measles/base.py
+++ b/src/laser/measles/base.py
@@ -44,15 +44,13 @@ from laser.measles.wrapper import pretty_laserframe
 class ParamsProtocol(Protocol):
     """Protocol defining the expected structure of model parameters.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.biweekly import BiweeklyParams
 
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         params.time_step_days  # 14 (biweekly)
         params.states          # ["S", "I", "R"]
-        ```
     """
 
     seed: int
@@ -113,13 +111,11 @@ class BaseModelParams(BaseModel):
             Falls back to pure Python if numba is unavailable.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.biweekly import BiweeklyParams
 
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
-        ```
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -163,13 +159,11 @@ class BaseModelParams(BaseModel):
 class BasePatchLaserFrame(LaserFrame):
     """LaserFrame that has a states property.
 
-    **Example:**
+    Examples:
 
-        ```python
         model.run()
         model.patches.S  # shape (nticks+1, num_patches), susceptible counts
         model.patches.I  # shape (nticks+1, num_patches), infectious counts
-        ```
     """
 
     states: StateArray  # StateArray with attribute access (S, E, I, R, etc.)
@@ -183,15 +177,12 @@ class BasePeopleLaserFrame(LaserFrame):
     This class provides factory methods for creating new instances with the same
     properties but different capacity, making it easy to resize people collections.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         # ABM models have a people LaserFrame for individual agents
         model.people.state     # agent health states
         model.people.age       # agent ages in days
         model.people.patch_id  # which patch each agent belongs to
-        ```
     """
 
     @classmethod
@@ -264,10 +255,8 @@ class BaseLaserModel(ABC):
     Provides common functionality for model initialization, component management,
     timing, metrics collection, and execution loops.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
 
@@ -275,7 +264,6 @@ class BaseLaserModel(ABC):
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.run()
-        ```
     """
 
     ScenarioType = TypeVar("ScenarioType")
@@ -604,7 +592,8 @@ class BaseLaserModel(ABC):
             List of instances of the specified class, or [None] if none found.
             Works with inheritance - subclasses will match parent class searches.
 
-        Example:
+        Examples:
+
             state_trackers = model.get_instance(StateTracker)
             if state_trackers:
                 state_tracker = state_trackers[0]  # Get first instance
@@ -734,15 +723,12 @@ class BaseComponent:
     Components follow a uniform interface with __call__(model, tick) method
     for execution during simulation loops.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams, components
         from laser.measles import create_component
 
         model.add_component(create_component(components.InfectionProcess, components.InfectionParams(beta=0.57)))
-        ```
     """
 
     ModelType = TypeVar("ModelType")
@@ -795,7 +781,8 @@ class BaseComponent:
         Returns:
             The selected function implementation.
 
-        Example:
+        Examples:
+
             >>> # In a component's __init__ or _initialize method:
             >>> self.update_func = self.select_function(numpy_update, numba_update)
         """
@@ -833,17 +820,14 @@ class BasePhase(BaseComponent):
 
     Phases are components that are called every tick and include a __call__ method.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.biweekly import components
         from laser.measles import create_component
 
         # Processes (BasePhase subclasses) execute in order each tick
         model.add_component(create_component(components.VitalDynamicsProcess, components.VitalDynamicsParams()))
         model.add_component(create_component(components.InfectionProcess, components.InfectionParams()))
-        ```
     """
 
     @abstractmethod
@@ -868,15 +852,12 @@ class BaseScenario(ABC):
     Provides a wrapper around polars DataFrames with additional validation
     and convenience methods.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
 
         scenario = single_patch_scenario(population=100_000, mcv1_coverage=0.85)
         # scenario is a Polars DataFrame with columns: id, pop, lat, lon, mcv1
-        ```
     """
 
     def __init__(self, df: pl.DataFrame):

--- a/src/laser/measles/biweekly/base.py
+++ b/src/laser/measles/biweekly/base.py
@@ -13,12 +13,10 @@ from laser.measles.base import BaseScenario
 class PatchLaserFrame(BasePatchLaserFrame):
     """Patch-level LaserFrame for the biweekly model.
 
-    **Example:**
+    Examples:
 
-        ```python
         model.patches.S  # susceptible counts, shape (nticks+1, num_patches)
         model.patches.I  # infectious counts
-        ```
     """
 
 
@@ -26,15 +24,12 @@ class BaseScenarioSchema(pt.Model):
     """
     Schema for the scenario data.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
 
         scenario = single_patch_scenario(population=100_000, mcv1_coverage=0.85)
         # Validated automatically when passed to BiweeklyModel(scenario, params)
-        ```
     """
 
     pop: int  # population
@@ -54,14 +49,11 @@ class BaseBiweeklyScenario(BaseScenario):
     Args:
         df: Polars DataFrame with patch-level data.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
 
         scenario = single_patch_scenario(population=100_000, mcv1_coverage=0.85)
-        ```
     """
 
     def __init__(self, df: pl.DataFrame):

--- a/src/laser/measles/biweekly/components/process_constant_pop.py
+++ b/src/laser/measles/biweekly/components/process_constant_pop.py
@@ -10,13 +10,11 @@ from laser.measles.utils import cast_type
 class ConstantPopParams(BaseConstantPopParams):
     """Parameters for constant-population vital dynamics (inherits all fields from base).
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.biweekly.components.process_constant_pop import ConstantPopParams
 
         params = ConstantPopParams(crude_birth_rate=20)
-        ```
     """
 
 
@@ -25,15 +23,12 @@ class ConstantPopProcess(BaseConstantPopProcess):
     A component to handle the birth events in a model with constant population - that is, births == deaths.
 
     Attributes:
-
         model: The model instance containing population and parameters.
         initializers (list): List of initializers to be called on birth events.
         metrics (DataFrame): DataFrame to holding timing metrics for initializers.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -43,7 +38,6 @@ class ConstantPopProcess(BaseConstantPopProcess):
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.add_component(create_component(components.ConstantPopProcess, components.ConstantPopParams(crude_birth_rate=20)))
-        ```
     """
 
     def __call__(self, model, tick) -> None:
@@ -51,17 +45,15 @@ class ConstantPopProcess(BaseConstantPopProcess):
         Adds new agents to each patch based on expected daily births calculated from CBR. Calls each of the registered initializers for the newborns.
 
         Args:
-
             model: The simulation model containing patches, population, and parameters.
             tick: The current time step in the simulation.
 
         Returns:
-
             None
 
         This method performs the following steps:
 
-            1. Draw a random set of indices, or size size "number of births"  from the population,
+        1. Draw a random set of indices, or size size "number of births"  from the population,
         """
 
         patches = model.patches

--- a/src/laser/measles/biweekly/components/process_importation_pressure.py
+++ b/src/laser/measles/biweekly/components/process_importation_pressure.py
@@ -47,62 +47,49 @@ class ImportationPressureParams(BaseModel):
     Examples:
         Uniform low background pressure across all patches:
 
-        ```python
-        params = ImportationPressureParams(crude_importation_rate=0.05)
-        ```
+            params = ImportationPressureParams(crude_importation_rate=0.05)
 
         Disable importation entirely:
 
-        ```python
-        params = ImportationPressureParams(crude_importation_rate=0.0)
-        ```
+            params = ImportationPressureParams(crude_importation_rate=0.0)
 
         Per-patch sequence (one entry per patch, aligned to scenario row order):
 
-        ```python
-        # 25-patch model; patch at row index 12 is the metro hub
-        rates = [0.02] * 25
-        rates[12] = 0.5
-        params = ImportationPressureParams(crude_importation_rate=rates)
-        ```
+            # 25-patch model; patch at row index 12 is the metro hub
+            rates = [0.02] * 25
+            rates[12] = 0.5
+            params = ImportationPressureParams(crude_importation_rate=rates)
 
         Sparse dict — only named patches receive importation; all others get 0.0:
 
-        ```python
-        # Use string ids from model.scenario["id"], e.g. "n_0_0", "n_2_2"
-        params = ImportationPressureParams(
-            crude_importation_rate={"n_2_2": 0.5, "n_0_0": 0.1},
-        )
-        ```
+            # Use string ids from model.scenario["id"], e.g. "n_0_0", "n_2_2"
+            params = ImportationPressureParams(
+                crude_importation_rate={"n_2_2": 0.5, "n_0_0": 0.1},
+            )
 
         Numpy array input (accepted and converted to list internally):
 
-        ```python
-        import numpy as np
-        params = ImportationPressureParams(
-            crude_importation_rate=np.array([0.01, 0.05, 0.01, 0.01, 0.01])
-        )
-        ```
+            import numpy as np
+            params = ImportationPressureParams(
+                crude_importation_rate=np.array([0.01, 0.05, 0.01, 0.01, 0.01])
+            )
 
         Time-windowed importation active only during the first year (days 0-364):
 
-        ```python
-        params = ImportationPressureParams(
-            crude_importation_rate=0.1,
-            importation_start=0,
-            importation_end=364,
-        )
-        ```
+            params = ImportationPressureParams(
+                crude_importation_rate=0.1,
+                importation_start=0,
+                importation_end=364,
+            )
+
 
         Metro-only importation for the first year, then stop:
 
-        ```python
-        params = ImportationPressureParams(
-            crude_importation_rate={"n_2_2": 2.0},
-            importation_start=0,
-            importation_end=364,
-        )
-        ```
+            params = ImportationPressureParams(
+                crude_importation_rate={"n_2_2": 2.0},
+                importation_start=0,
+                importation_end=364,
+            )
     """
 
     model_config = ConfigDict(extra="forbid")

--- a/src/laser/measles/biweekly/components/process_importation_pressure.py
+++ b/src/laser/measles/biweekly/components/process_importation_pressure.py
@@ -45,50 +45,64 @@ class ImportationPressureParams(BaseModel):
             ``importation_start`` when not ``-1``.
 
     Examples:
-        Uniform low background pressure across all patches::
+        Uniform low background pressure across all patches:
 
-            params = ImportationPressureParams(crude_importation_rate=0.05)
+        ```python
+        params = ImportationPressureParams(crude_importation_rate=0.05)
+        ```
 
-        Disable importation entirely::
+        Disable importation entirely:
 
-            params = ImportationPressureParams(crude_importation_rate=0.0)
+        ```python
+        params = ImportationPressureParams(crude_importation_rate=0.0)
+        ```
 
-        Per-patch sequence (one entry per patch, aligned to scenario row order)::
+        Per-patch sequence (one entry per patch, aligned to scenario row order):
 
-            # 25-patch model; patch at row index 12 is the metro hub
-            rates = [0.02] * 25
-            rates[12] = 0.5
-            params = ImportationPressureParams(crude_importation_rate=rates)
+        ```python
+        # 25-patch model; patch at row index 12 is the metro hub
+        rates = [0.02] * 25
+        rates[12] = 0.5
+        params = ImportationPressureParams(crude_importation_rate=rates)
+        ```
 
-        Sparse dict — only named patches receive importation; all others get 0.0::
+        Sparse dict — only named patches receive importation; all others get 0.0:
 
-            # Use string ids from model.scenario["id"], e.g. "n_0_0", "n_2_2"
-            params = ImportationPressureParams(
-                crude_importation_rate={"n_2_2": 0.5, "n_0_0": 0.1},
-            )
+        ```python
+        # Use string ids from model.scenario["id"], e.g. "n_0_0", "n_2_2"
+        params = ImportationPressureParams(
+            crude_importation_rate={"n_2_2": 0.5, "n_0_0": 0.1},
+        )
+        ```
 
-        Numpy array input (accepted and converted to list internally)::
+        Numpy array input (accepted and converted to list internally):
 
-            import numpy as np
-            params = ImportationPressureParams(
-                crude_importation_rate=np.array([0.01, 0.05, 0.01, 0.01, 0.01])
-            )
+        ```python
+        import numpy as np
+        params = ImportationPressureParams(
+            crude_importation_rate=np.array([0.01, 0.05, 0.01, 0.01, 0.01])
+        )
+        ```
 
-        Time-windowed importation active only during the first year (days 0-364)::
+        Time-windowed importation active only during the first year (days 0-364):
 
-            params = ImportationPressureParams(
-                crude_importation_rate=0.1,
-                importation_start=0,
-                importation_end=364,
-            )
+        ```python
+        params = ImportationPressureParams(
+            crude_importation_rate=0.1,
+            importation_start=0,
+            importation_end=364,
+        )
+        ```
 
-        Metro-only importation for the first year, then stop::
+        Metro-only importation for the first year, then stop:
 
-            params = ImportationPressureParams(
-                crude_importation_rate={"n_2_2": 2.0},
-                importation_start=0,
-                importation_end=364,
-            )
+        ```python
+        params = ImportationPressureParams(
+            crude_importation_rate={"n_2_2": 2.0},
+            importation_start=0,
+            importation_end=364,
+        )
+        ```
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -153,27 +167,22 @@ class ImportationPressureProcess(BasePhase):
 
     This component handles the simulation of disease importation into the population.
     It processes:
+
     - Importation of cases based on crude importation rate
     - Time-windowed importation (start/end times)
     - Population updates: Moves individuals from susceptible to infected state
 
-    Parameters
-    ----------
-    model : object
-        The simulation model containing nodes, states, and parameters
-    params : Optional[ImportationPressureParams], default=None
-        Component-specific parameters. If None, will use default parameters
+    Args:
+        model: The simulation model containing nodes, states, and parameters
+        params: Component-specific parameters. If None, will use default parameters
 
-    Notes
-    -----
-    - Importation rates are calculated per year
-    - Importation is limited to the susceptible population
-    - All state counts are ensured to be non-negative
+    Note:
+        - Importation rates are calculated per year
+        - Importation is limited to the susceptible population
+        - All state counts are ensured to be non-negative
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -183,7 +192,6 @@ class ImportationPressureProcess(BasePhase):
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.add_component(create_component(components.ImportationPressureProcess, components.ImportationPressureParams()))
-        ```
     """
 
     def __init__(self, model: BiweeklyModel, params: ImportationPressureParams | None = None) -> None:

--- a/src/laser/measles/biweekly/components/process_infection.py
+++ b/src/laser/measles/biweekly/components/process_infection.py
@@ -13,13 +13,11 @@ from laser.measles.mixing.gravity import GravityMixing
 class InfectionParams(BaseInfectionParams):
     """Parameters specific to the infection process component.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.biweekly.components.process_infection import InfectionParams
 
         params = InfectionParams(beta=0.57, seasonality=0.2)
-        ```
     """
 
     beta: float = Field(
@@ -57,35 +55,29 @@ class InfectionProcess(BaseInfectionProcess):
 
     1. Calculates expected new infections based on:
 
-       - Base transmission rate (beta)
-       - Seasonal variation
-       - Population mixing matrix
-       - Current number of infected individuals
+        - Base transmission rate (beta)
+        - Seasonal variation
+        - Population mixing matrix
+        - Current number of infected individuals
 
     2. Converts expected infections to probabilities
     3. Samples actual new infections from a binomial distribution
     4. Updates population states:
 
-       - Moves current infected to recovered (configurable recovery period)
-       - Adds new infections to infected population
-       - Removes new infections from susceptible population
+        - Moves current infected to recovered (configurable recovery period)
+        - Adds new infections to infected population
+        - Removes new infections from susceptible population
 
-    Parameters
-    ----------
-    model : object
-        The simulation model containing population states and parameters
-    params : InfectionParams | None, default=None
-        Component-specific parameters. If None, will use default parameters
+    Args:
+        model: The simulation model containing population states and parameters
+        params: Component-specific parameters. If None, will use default parameters
 
-    Notes
-    -----
-    The infection process uses a configurable recovery period and seasonal
-    transmission rate that varies sinusoidally over time.
+    Note:
+        The infection process uses a configurable recovery period and seasonal
+        transmission rate that varies sinusoidally over time.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -95,7 +87,6 @@ class InfectionProcess(BaseInfectionProcess):
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.add_component(create_component(components.InfectionProcess, components.InfectionParams(beta=0.57)))
-        ```
     """
 
     def __init__(self, model: BaseLaserModel, params: InfectionParams | None = None) -> None:

--- a/src/laser/measles/biweekly/components/process_infection_seeding.py
+++ b/src/laser/measles/biweekly/components/process_infection_seeding.py
@@ -6,22 +6,19 @@ from laser.measles.components.base_infection_seeding import BaseInfectionSeeding
 class InfectionSeedingParams(BaseInfectionSeedingParams):
     """Parameters for infection seeding (inherits all fields from base).
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.biweekly.components.process_infection_seeding import InfectionSeedingParams
 
         params = InfectionSeedingParams()
-        ```
     """
 
 
 class InfectionSeedingProcess(BaseInfectionSeedingProcess):
     """Process infection seeding.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -31,7 +28,6 @@ class InfectionSeedingProcess(BaseInfectionSeedingProcess):
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.add_component(create_component(components.InfectionSeedingProcess, components.InfectionSeedingParams()))
-        ```
     """
 
     def _seed_infections_in_patch(self, model: BaseLaserModel, patch_idx: int, num_infections: int) -> int:

--- a/src/laser/measles/biweekly/components/process_initialize_equilibrium_states.py
+++ b/src/laser/measles/biweekly/components/process_initialize_equilibrium_states.py
@@ -10,14 +10,11 @@ class InitializeEquilibriumStatesParams(BaseInitializeEquilibriumStatesParams):
     """
     Parameters for the InitializeEquilibriumStatesProcess.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.biweekly.components.process_initialize_equilibrium_states import InitializeEquilibriumStatesParams
 
         params = InitializeEquilibriumStatesParams()
-        ```
     """
 
 
@@ -25,10 +22,8 @@ class InitializeEquilibriumStatesProcess(BaseInitializeEquilibriumStatesProcess)
     """
     Initialize S, R states of the population in each of the model states by rough equilibrium of R0.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -38,5 +33,4 @@ class InitializeEquilibriumStatesProcess(BaseInitializeEquilibriumStatesProcess)
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.add_component(create_component(components.InitializeEquilibriumStatesProcess, components.InitializeEquilibriumStatesParams()))
-        ```
     """

--- a/src/laser/measles/biweekly/components/process_sia_calendar.py
+++ b/src/laser/measles/biweekly/components/process_sia_calendar.py
@@ -15,13 +15,11 @@ from laser.measles.utils import coerce_utf8_date_column
 class SIACalendarParams(BaseModel):
     """Parameters specific to the SIA calendar component.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.biweekly.components.process_sia_calendar import SIACalendarParams
 
         params = SIACalendarParams()
-        ```
     """
 
     model_config = {"arbitrary_types_allowed": True}
@@ -49,30 +47,25 @@ class SIACalendarProcess(BasePhase):
     Phase for implementing Supplementary Immunization Activities (SIAs) based on a calendar schedule.
 
     This component:
+
     1. Groups nodes by geographic level using the same aggregation schema as CaseSurveillanceTracker
     2. Implements SIAs at scheduled times by moving susceptibles to recovered state
     3. Uses the model's current_date to determine when to implement SIAs
     4. Applies vaccination with configurable efficacy rate
 
-    Parameters
-    ----------
-    model : object
-        The simulation model containing nodes, states, and parameters
-    params : Optional[SIACalendarParams], default=None
-        Component-specific parameters. If None, will use default parameters
+    Args:
+        model (object): The simulation model containing nodes, states, and parameters
+        params (SAICalendarParams): Component-specific parameters. If None, will use default parameters
 
-    Notes
-    -----
-    - SIA efficacy determines the fraction of susceptibles that get vaccinated
-    - Vaccination is simulated using a binomial distribution
-    - SIAs are implemented when the model's current_date has passed the scheduled date
-    - Since the model steps in 14-day increments, SIAs are implemented on the first step after their scheduled date
-    - Each SIA is implemented exactly once
+    Note:
+        - SIA efficacy determines the fraction of susceptibles that get vaccinated
+        - Vaccination is simulated using a binomial distribution
+        - SIAs are implemented when the model's current_date has passed the scheduled date
+        - Since the model steps in 14-day increments, SIAs are implemented on the first step after their scheduled date
+        - Each SIA is implemented exactly once
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -82,7 +75,6 @@ class SIACalendarProcess(BasePhase):
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.add_component(create_component(components.SIACalendarProcess, components.SIACalendarParams()))
-        ```
     """
 
     def __init__(self, model, params: SIACalendarParams | None = None) -> None:
@@ -169,10 +161,9 @@ class SIACalendarProcess(BasePhase):
         """
         Get the SIA schedule.
 
-        Returns
-        -------
-        pl.DataFrame
-            DataFrame with columns:
+        Returns:
+            pl.DataFrame: DataFrame with columns:
+
             - {group_column}: Group identifier
             - {date_column}: Scheduled date for SIA
         """

--- a/src/laser/measles/biweekly/components/process_vital_dynamics.py
+++ b/src/laser/measles/biweekly/components/process_vital_dynamics.py
@@ -6,14 +6,11 @@ class VitalDynamicsParams(BaseVitalDynamicsParams):
     """
     Parameters for the vital dynamics process.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.biweekly.components.process_vital_dynamics import VitalDynamicsParams
 
         params = VitalDynamicsParams()
-        ```
     """
 
 
@@ -21,10 +18,8 @@ class VitalDynamicsProcess(BaseVitalDynamicsProcess):
     """
     Phase for simulating the vital dynamics in the model with MCV1.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -34,7 +29,6 @@ class VitalDynamicsProcess(BaseVitalDynamicsProcess):
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.add_component(create_component(components.VitalDynamicsProcess, components.VitalDynamicsParams()))
-        ```
     """
 
     def calculate_capacity(self, model) -> int:

--- a/src/laser/measles/biweekly/components/tracker_case_surveillance.py
+++ b/src/laser/measles/biweekly/components/tracker_case_surveillance.py
@@ -5,22 +5,19 @@ from laser.measles.components import BaseCaseSurveillanceTracker
 class CaseSurveillanceParams(BaseCaseSurveillanceParams):
     """Parameters for CaseSurveillanceParams (inherits all fields from base).
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.biweekly.components.tracker_case_surveillance import CaseSurveillanceParams
 
         params = CaseSurveillanceParams()
-        ```
     """
 
 
 class CaseSurveillanceTracker(BaseCaseSurveillanceTracker):
     """Tracks detected cases in the model.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -30,5 +27,4 @@ class CaseSurveillanceTracker(BaseCaseSurveillanceTracker):
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.add_component(create_component(components.CaseSurveillanceTracker, components.CaseSurveillanceParams()))
-        ```
     """

--- a/src/laser/measles/biweekly/components/tracker_fadeout.py
+++ b/src/laser/measles/biweekly/components/tracker_fadeout.py
@@ -5,9 +5,8 @@ from laser.measles.components import BaseFadeOutTrackerParams
 class FadeOutTracker(BaseFadeOutTracker):
     """A component that tracks the number of nodes experiencing fade-outs over time.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -17,7 +16,6 @@ class FadeOutTracker(BaseFadeOutTracker):
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.add_component(create_component(components.FadeOutTracker, components.FadeOutTrackerParams()))
-        ```
     """
 
     def __init__(self, model) -> None:
@@ -27,11 +25,9 @@ class FadeOutTracker(BaseFadeOutTracker):
 class FadeOutTrackerParams(BaseFadeOutTrackerParams):
     """Parameters for the FadeOutTracker component.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.biweekly.components.tracker_fadeout import FadeOutTrackerParams
 
         params = FadeOutTrackerParams()
-        ```
     """

--- a/src/laser/measles/biweekly/components/tracker_population.py
+++ b/src/laser/measles/biweekly/components/tracker_population.py
@@ -9,9 +9,8 @@ class PopulationTracker(BasePopulationTracker):
     ``(n_patches, n_ticks)``) after ``model.run()``. Sum across the patch
     axis for the global population time series.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -28,18 +27,15 @@ class PopulationTracker(BasePopulationTracker):
         pop_per_patch = tracker.population_tracker     # shape (n_patches, n_ticks)
         pop_global = pop_per_patch.sum(axis=0)         # shape (n_ticks,)
         print(f"start: {pop_global[0]:,}, end: {pop_global[-1]:,}")
-        ```
     """
 
 
 class PopulationTrackerParams(BasePopulationTrackerParams):
     """Parameters for PopulationTrackerParams (inherits all fields from base).
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.biweekly.components.tracker_population import PopulationTrackerParams
 
         params = PopulationTrackerParams()
-        ```
     """

--- a/src/laser/measles/biweekly/components/tracker_state.py
+++ b/src/laser/measles/biweekly/components/tracker_state.py
@@ -9,14 +9,11 @@ class StateTrackerParams(BaseStateTrackerParams):
     Inherits all parameters from BaseStateTrackerParams with
     ABM-specific defaults and validation.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.biweekly.components.tracker_state import StateTrackerParams
 
         params = StateTrackerParams()
-        ```
     """
 
 
@@ -28,10 +25,8 @@ class StateTracker(BaseStateTracker):
     Records detailed temporal dynamics of S, I, R compartments
     at the patch level.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -41,5 +36,4 @@ class StateTracker(BaseStateTracker):
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.add_component(create_component(components.StateTracker, components.StateTrackerParams()))
-        ```
     """

--- a/src/laser/measles/biweekly/model.py
+++ b/src/laser/measles/biweekly/model.py
@@ -39,16 +39,14 @@ class BiweeklyModel(BaseLaserModel):
         name (str): Display name for log messages.  Defaults to
             ``"biweekly"``.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
 
         params = BiweeklyParams(num_ticks=26, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario=df, params=params)
         model.components = [InfectionSeedingProcess, InfectionProcess]
         model.run()
-        ```
     """
 
     patches: PatchLaserFrame
@@ -75,12 +73,10 @@ class BiweeklyModel(BaseLaserModel):
         Updates the model for the next tick.
 
         Args:
-
             model: The model containing the patches and their populations.
             tick (int): The current time step or tick.
 
         Returns:
-
             None
         """
         return

--- a/src/laser/measles/biweekly/params.py
+++ b/src/laser/measles/biweekly/params.py
@@ -25,11 +25,9 @@ class BiweeklyParams(BaseModelParams):
             Default: ``"2000-01"``.
         verbose: Print detailed logging.  Default: ``False``.
 
-    **Example:**
+    Examples:
 
-        ```python
         params = BiweeklyParams(num_ticks=26, seed=42, start_time="2000-01")
-        ```
     """
 
     @property

--- a/src/laser/measles/compartmental/base.py
+++ b/src/laser/measles/compartmental/base.py
@@ -15,13 +15,11 @@ from laser.measles.base import BaseScenario
 class PatchLaserFrame(BasePatchLaserFrame):
     """Patch-level LaserFrame for the compartmental model.
 
-    **Example:**
+    Examples:
 
-        ```python
         model.patches.S  # susceptible counts, shape (nticks+1, num_patches)
         model.patches.E  # exposed counts (SEIR model)
         model.patches.I  # infectious counts
-        ```
     """
 
 
@@ -30,14 +28,12 @@ class BaseScenarioSchema(pt.Model):
     Schema for the scenario data.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
 
         scenario = single_patch_scenario(population=100_000, mcv1_coverage=0.85)
         # Validated automatically when passed to CompartmentalModel(scenario, params)
-        ```
     """
 
     pop: int  # population
@@ -58,13 +54,11 @@ class BaseCompartmentalScenario(BaseScenario):
         df: Polars DataFrame with patch-level data.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
 
         scenario = single_patch_scenario(population=100_000, mcv1_coverage=0.85)
-        ```
     """
 
     def __init__(self, df: pl.DataFrame):

--- a/src/laser/measles/compartmental/components/process_constant_pop.py
+++ b/src/laser/measles/compartmental/components/process_constant_pop.py
@@ -10,13 +10,11 @@ from laser.measles.utils import cast_type
 class ConstantPopParams(BaseConstantPopParams):
     """Parameters for constant-population vital dynamics (inherits all fields from base).
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.compartmental.components.process_constant_pop import ConstantPopParams
 
         params = ConstantPopParams(crude_birth_rate=20)
-        ```
     """
 
 
@@ -25,15 +23,13 @@ class ConstantPopProcess(BaseConstantPopProcess):
     A component to handle the birth events in a model with constant population - that is, births == deaths.
 
     Attributes:
-
         model: The model instance containing population and parameters.
         initializers (list): List of initializers to be called on birth events.
         metrics (DataFrame): DataFrame to holding timing metrics for initializers.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.compartmental import CompartmentalModel, CompartmentalParams
         from laser.measles.compartmental import components
@@ -43,7 +39,6 @@ class ConstantPopProcess(BaseConstantPopProcess):
         params = CompartmentalParams(num_ticks=365, seed=42, start_time="2000-01")
         model = CompartmentalModel(scenario, params)
         model.add_component(create_component(components.ConstantPopProcess, components.ConstantPopParams(crude_birth_rate=20)))
-        ```
     """
 
     def __call__(self, model, tick) -> None:
@@ -51,17 +46,15 @@ class ConstantPopProcess(BaseConstantPopProcess):
         Adds new agents to each patch based on expected daily births calculated from CBR. Calls each of the registered initializers for the newborns.
 
         Args:
-
             model: The simulation model containing patches, population, and parameters.
             tick: The current time step in the simulation.
 
         Returns:
-
             None
 
         This method performs the following steps:
 
-            1. Draw a random set of indices, or size size "number of births"  from the population,
+        1. Draw a random set of indices, or size size "number of births"  from the population,
         """
 
         patches = model.patches

--- a/src/laser/measles/compartmental/components/process_importation_pressure.py
+++ b/src/laser/measles/compartmental/components/process_importation_pressure.py
@@ -50,50 +50,64 @@ class ImportationPressureParams(BaseModel):
             greater than ``importation_start`` when not ``-1``.
 
     Examples:
-        Uniform low background pressure across all patches::
+        Uniform low background pressure across all patches:
 
-            params = ImportationPressureParams(crude_importation_rate=0.05)
+        ```python
+        params = ImportationPressureParams(crude_importation_rate=0.05)
+        ```
 
-        Disable importation entirely::
+        Disable importation entirely:
 
-            params = ImportationPressureParams(crude_importation_rate=0.0)
+        ```python
+        params = ImportationPressureParams(crude_importation_rate=0.0)
+        ```
 
-        Per-patch sequence (one entry per patch, aligned to scenario row order)::
+        Per-patch sequence (one entry per patch, aligned to scenario row order):
 
-            # 25-patch model; patch at row index 12 is the metro hub
-            rates = [0.02] * 25
-            rates[12] = 0.5
-            params = ImportationPressureParams(crude_importation_rate=rates)
+        ```python
+        # 25-patch model; patch at row index 12 is the metro hub
+        rates = [0.02] * 25
+        rates[12] = 0.5
+        params = ImportationPressureParams(crude_importation_rate=rates)
+        ```
 
-        Sparse dict — only named patches receive importation; all others get 0.0::
+        Sparse dict — only named patches receive importation; all others get 0.0:
 
-            # Use string ids from model.scenario["id"], e.g. "n_0_0", "n_2_2"
-            params = ImportationPressureParams(
-                crude_importation_rate={"n_2_2": 0.5, "n_0_0": 0.1},
-            )
+        ```python
+        # Use string ids from model.scenario["id"], e.g. "n_0_0", "n_2_2"
+        params = ImportationPressureParams(
+            crude_importation_rate={"n_2_2": 0.5, "n_0_0": 0.1},
+        )
+        ```
 
-        Numpy array input (accepted and converted to list internally)::
+        Numpy array input (accepted and converted to list internally):
 
-            import numpy as np
-            params = ImportationPressureParams(
-                crude_importation_rate=np.array([0.01, 0.05, 0.01, 0.01, 0.01])
-            )
+        ```python
+        import numpy as np
+        params = ImportationPressureParams(
+            crude_importation_rate=np.array([0.01, 0.05, 0.01, 0.01, 0.01])
+        )
+        ```
 
-        Time-windowed importation active only during the first year (days 0-364)::
+        Time-windowed importation active only during the first year (days 0-364):
 
-            params = ImportationPressureParams(
-                crude_importation_rate=0.1,
-                importation_start=0,
-                importation_end=364,
-            )
+        ```python
+        params = ImportationPressureParams(
+            crude_importation_rate=0.1,
+            importation_start=0,
+            importation_end=364,
+        )
+        ```
 
-        Metro-only importation for the first year, then stop::
+        Metro-only importation for the first year, then stop:
 
-            params = ImportationPressureParams(
-                crude_importation_rate={"n_2_2": 2.0},
-                importation_start=0,
-                importation_end=364,
-            )
+        ```python
+        params = ImportationPressureParams(
+            crude_importation_rate={"n_2_2": 2.0},
+            importation_start=0,
+            importation_end=364,
+        )
+        ```
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -162,23 +176,18 @@ class ImportationPressureProcess(BasePhase):
     - Time-windowed importation (start/end times)
     - Population updates: Moves individuals from susceptible to exposed state
 
-    Parameters
-    ----------
-    model : object
-        The simulation model containing nodes, states, and parameters
-    params : Optional[ImportationPressureParams], default=None
-        Component-specific parameters. If None, will use default parameters
+    Args:
+        model (object): The simulation model containing nodes, states, and parameters
+        params (Optional[ImportationPressureParams], default=None): Component-specific parameters. If None, will use default parameters
 
-    Notes
-    -----
-    - Importation rates are calculated per year
-    - Importation is limited to the susceptible population
-    - All state counts are ensured to be non-negative
+    Notes:
+        - Importation rates are calculated per year
+        - Importation is limited to the susceptible population
+        - All state counts are ensured to be non-negative
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.compartmental import CompartmentalModel, CompartmentalParams
         from laser.measles.compartmental import components
@@ -188,7 +197,6 @@ class ImportationPressureProcess(BasePhase):
         params = CompartmentalParams(num_ticks=365, seed=42, start_time="2000-01")
         model = CompartmentalModel(scenario, params)
         model.add_component(create_component(components.ImportationPressureProcess, components.ImportationPressureParams()))
-        ```
     """
 
     def __init__(self, model, params: ImportationPressureParams | None = None) -> None:

--- a/src/laser/measles/compartmental/components/process_infection.py
+++ b/src/laser/measles/compartmental/components/process_infection.py
@@ -19,14 +19,14 @@ class InfectionParams(BaseInfectionParams):
     """Parameters for the compartmental SEIR infection process.
 
     Spatial mixing is configured via the ``mixer`` parameter. Any
-    :class:`~laser.measles.mixing.base.BaseMixing` subclass is accepted
-    (e.g. :class:`~laser.measles.mixing.gravity.GravityMixing`,
-    :class:`~laser.measles.mixing.radiation.RadiationMixing`).
+    [`BaseMixing`][laser.measles.mixing.base.BaseMixing] subclass is accepted
+    (e.g. [`GravityMixing`][laser.measles.mixing.gravity.GravityMixing],
+    [`RadiationMixing`][laser.measles.mixing.radiation.RadiationMixing]).
     The model sets the patch scenario on the mixer automatically at
     initialisation, so passing ``scenario=`` to the mixer at construction
     is not required.
 
-    Example::
+    Examples:
 
         from laser.measles.mixing.gravity import GravityMixing, GravityParams
 
@@ -107,22 +107,17 @@ class InfectionProcess(BaseInfectionProcess):
 
     3. Update population states for all compartments
 
-    Parameters
-    ----------
-    model : object
-        The simulation model containing population states and parameters
-    params : InfectionParams | None, default=None
-        Component-specific parameters. If None, will use default parameters
+    Args:
+        model (object): The simulation model containing population states and parameters
+        params (InfectionParams | None, default=None): Component-specific parameters. If None, will use default parameters
 
-    Notes
-    -----
-    The infection process uses daily rates and seasonal transmission that varies
-    sinusoidally over time with a period of 365 days.
+    Notes:
+        The infection process uses daily rates and seasonal transmission that varies
+        sinusoidally over time with a period of 365 days.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.compartmental import CompartmentalModel, CompartmentalParams
         from laser.measles.compartmental import components
@@ -132,7 +127,6 @@ class InfectionProcess(BaseInfectionProcess):
         params = CompartmentalParams(num_ticks=365, seed=42, start_time="2000-01")
         model = CompartmentalModel(scenario, params)
         model.add_component(create_component(components.InfectionProcess, components.InfectionParams(beta=0.8)))
-        ```
     """
 
     def __init__(self, model: BaseLaserModel, params: InfectionParams | None = None) -> None:

--- a/src/laser/measles/compartmental/components/process_infection_seeding.py
+++ b/src/laser/measles/compartmental/components/process_infection_seeding.py
@@ -6,22 +6,19 @@ from laser.measles.components.base_infection_seeding import BaseInfectionSeeding
 class InfectionSeedingParams(BaseInfectionSeedingParams):
     """Parameters for infection seeding (inherits all fields from base).
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.compartmental.components.process_infection_seeding import InfectionSeedingParams
 
         params = InfectionSeedingParams()
-        ```
     """
 
 
 class InfectionSeedingProcess(BaseInfectionSeedingProcess):
     """Process infection seeding.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.compartmental import CompartmentalModel, CompartmentalParams
         from laser.measles.compartmental import components
@@ -31,7 +28,6 @@ class InfectionSeedingProcess(BaseInfectionSeedingProcess):
         params = CompartmentalParams(num_ticks=365, seed=42, start_time="2000-01")
         model = CompartmentalModel(scenario, params)
         model.add_component(create_component(components.InfectionSeedingProcess, components.InfectionSeedingParams()))
-        ```
     """
 
     def _seed_infections_in_patch(self, model: BaseLaserModel, patch_idx: int, num_infections: int) -> int:

--- a/src/laser/measles/compartmental/components/process_initialize_equilibrium_states.py
+++ b/src/laser/measles/compartmental/components/process_initialize_equilibrium_states.py
@@ -11,13 +11,11 @@ class InitializeEquilibriumStatesParams(BaseInitializeEquilibriumStatesParams):
     Parameters for the InitializeEquilibriumStatesProcess.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.compartmental.components.process_initialize_equilibrium_states import InitializeEquilibriumStatesParams
 
         params = InitializeEquilibriumStatesParams()
-        ```
     """
 
 
@@ -26,9 +24,8 @@ class InitializeEquilibriumStatesProcess(BaseInitializeEquilibriumStatesProcess)
     Initialize S, R states of the population in each of the model states by rough equilibrium of R0.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.compartmental import CompartmentalModel, CompartmentalParams
         from laser.measles.compartmental import components
@@ -38,5 +35,4 @@ class InitializeEquilibriumStatesProcess(BaseInitializeEquilibriumStatesProcess)
         params = CompartmentalParams(num_ticks=365, seed=42, start_time="2000-01")
         model = CompartmentalModel(scenario, params)
         model.add_component(create_component(components.InitializeEquilibriumStatesProcess, components.InitializeEquilibriumStatesParams()))
-        ```
     """

--- a/src/laser/measles/compartmental/components/process_sia_calendar.py
+++ b/src/laser/measles/compartmental/components/process_sia_calendar.py
@@ -22,13 +22,11 @@ from laser.measles.utils import coerce_utf8_date_column
 class SIACalendarParams(BaseModel):
     """Parameters specific to the SIA calendar component.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.compartmental.components.process_sia_calendar import SIACalendarParams
 
         params = SIACalendarParams()
-        ```
     """
 
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
@@ -61,25 +59,20 @@ class SIACalendarProcess(BasePhase):
     3. Uses the model's current_date to determine when to implement SIAs
     4. Applies vaccination with configurable efficacy rate
 
-    Parameters
-    ----------
-    model : object
-        The simulation model containing nodes, states, and parameters
-    params : Optional[SIACalendarParams], default=None
-        Component-specific parameters. If None, will use default parameters
+    Args:
+        model (object): The simulation model containing nodes, states, and parameters
+        params (Optional[SIACalendarParams], default=None): Component-specific parameters. If None, will use default parameters
 
-    Notes
-    -----
-    - SIA efficacy determines the fraction of susceptibles that get vaccinated
-    - Vaccination is simulated using a binomial distribution
-    - SIAs are implemented when the model's current_date has passed the scheduled date
-    - Since the model steps in 14-day increments, SIAs are implemented on the first step after their scheduled date
-    - Each SIA is implemented exactly once
+    Notes:
+        - SIA efficacy determines the fraction of susceptibles that get vaccinated
+        - Vaccination is simulated using a binomial distribution
+        - SIAs are implemented when the model's current_date has passed the scheduled date
+        - Since the model steps in 14-day increments, SIAs are implemented on the first step after their scheduled date
+        - Each SIA is implemented exactly once
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.compartmental import CompartmentalModel, CompartmentalParams
         from laser.measles.compartmental import components
@@ -89,7 +82,6 @@ class SIACalendarProcess(BasePhase):
         params = CompartmentalParams(num_ticks=365, seed=42, start_time="2000-01")
         model = CompartmentalModel(scenario, params)
         model.add_component(create_component(components.SIACalendarProcess, components.SIACalendarParams()))
-        ```
     """
 
     def __init__(self, model: CompartmentalModel, params: SIACalendarParams | None = None) -> None:
@@ -200,11 +192,9 @@ class SIACalendarProcess(BasePhase):
         """
         Get the SIA schedule.
 
-        Returns
-        -------
-        pl.DataFrame
-            DataFrame with columns:
-            - {group_column}: Group identifier
-            - {date_column}: Scheduled date for SIA
+        Returns:
+            pl.DataFrame: DataFrame with columns:
+                - {group_column}: Group identifier
+                - {date_column}: Scheduled date for SIA
         """
         return self._original_schedule

--- a/src/laser/measles/compartmental/components/process_vital_dynamics.py
+++ b/src/laser/measles/compartmental/components/process_vital_dynamics.py
@@ -13,13 +13,11 @@ class VitalDynamicsParams(BaseVitalDynamicsParams):
     Parameters for the vital dynamics process.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.compartmental.components.process_vital_dynamics import VitalDynamicsParams
 
         params = VitalDynamicsParams()
-        ```
     """
 
 
@@ -28,9 +26,8 @@ class VitalDynamicsProcess(BaseVitalDynamicsProcess):
     Phase for simulating the vital dynamics in the model with MCV1.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.compartmental import CompartmentalModel, CompartmentalParams
         from laser.measles.compartmental import components
@@ -40,7 +37,6 @@ class VitalDynamicsProcess(BaseVitalDynamicsProcess):
         params = CompartmentalParams(num_ticks=365, seed=42, start_time="2000-01")
         model = CompartmentalModel(scenario, params)
         model.add_component(create_component(components.VitalDynamicsProcess, components.VitalDynamicsParams()))
-        ```
     """
 
     def __init__(self, model, params: VitalDynamicsParams | None = None) -> None:

--- a/src/laser/measles/compartmental/components/tracker_case_surveillance.py
+++ b/src/laser/measles/compartmental/components/tracker_case_surveillance.py
@@ -5,22 +5,19 @@ from laser.measles.components import BaseCaseSurveillanceTracker
 class CaseSurveillanceParams(BaseCaseSurveillanceParams):
     """Parameters for CaseSurveillanceParams (inherits all fields from base).
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.compartmental.components.tracker_case_surveillance import CaseSurveillanceParams
 
         params = CaseSurveillanceParams()
-        ```
     """
 
 
 class CaseSurveillanceTracker(BaseCaseSurveillanceTracker):
     """Tracks detected cases in the model.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.compartmental import CompartmentalModel, CompartmentalParams
         from laser.measles.compartmental import components
@@ -30,5 +27,4 @@ class CaseSurveillanceTracker(BaseCaseSurveillanceTracker):
         params = CompartmentalParams(num_ticks=365, seed=42, start_time="2000-01")
         model = CompartmentalModel(scenario, params)
         model.add_component(create_component(components.CaseSurveillanceTracker, components.CaseSurveillanceParams()))
-        ```
     """

--- a/src/laser/measles/compartmental/components/tracker_fadeout.py
+++ b/src/laser/measles/compartmental/components/tracker_fadeout.py
@@ -5,9 +5,8 @@ from laser.measles.components import BaseFadeOutTrackerParams
 class FadeOutTracker(BaseFadeOutTracker):
     """A component that tracks the number of nodes experiencing fade-outs over time.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.compartmental import CompartmentalModel, CompartmentalParams
         from laser.measles.compartmental import components
@@ -17,18 +16,15 @@ class FadeOutTracker(BaseFadeOutTracker):
         params = CompartmentalParams(num_ticks=365, seed=42, start_time="2000-01")
         model = CompartmentalModel(scenario, params)
         model.add_component(create_component(components.FadeOutTracker, components.FadeOutTrackerParams()))
-        ```
     """
 
 
 class FadeOutTrackerParams(BaseFadeOutTrackerParams):
     """Parameters for the FadeOutTracker component.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.compartmental.components.tracker_fadeout import FadeOutTrackerParams
 
         params = FadeOutTrackerParams()
-        ```
     """

--- a/src/laser/measles/compartmental/components/tracker_population.py
+++ b/src/laser/measles/compartmental/components/tracker_population.py
@@ -9,9 +9,8 @@ class PopulationTracker(BasePopulationTracker):
     ``(n_patches, n_ticks)``) after ``model.run()``. Sum across the patch
     axis for the global population time series.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.compartmental import CompartmentalModel, CompartmentalParams
         from laser.measles.compartmental import components
@@ -28,18 +27,15 @@ class PopulationTracker(BasePopulationTracker):
         pop_per_patch = tracker.population_tracker     # shape (n_patches, n_ticks)
         pop_global = pop_per_patch.sum(axis=0)         # shape (n_ticks,)
         print(f"start: {pop_global[0]:,}, end: {pop_global[-1]:,}")
-        ```
     """
 
 
 class PopulationTrackerParams(BasePopulationTrackerParams):
     """Parameters for PopulationTrackerParams (inherits all fields from base).
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.compartmental.components.tracker_population import PopulationTrackerParams
 
         params = PopulationTrackerParams()
-        ```
     """

--- a/src/laser/measles/compartmental/components/tracker_state.py
+++ b/src/laser/measles/compartmental/components/tracker_state.py
@@ -14,13 +14,11 @@ class StateTrackerParams(BaseStateTrackerParams):
     ABM-specific defaults and validation.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.compartmental.components.tracker_state import StateTrackerParams
 
         params = StateTrackerParams()
-        ```
     """
 
 
@@ -33,9 +31,8 @@ class StateTracker(BaseStateTracker):
     at the patch level.
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.compartmental import CompartmentalModel, CompartmentalParams
         from laser.measles.compartmental import components
@@ -45,5 +42,4 @@ class StateTracker(BaseStateTracker):
         params = CompartmentalParams(num_ticks=365, seed=42, start_time="2000-01")
         model = CompartmentalModel(scenario, params)
         model.add_component(create_component(components.StateTracker, components.StateTrackerParams()))
-        ```
     """

--- a/src/laser/measles/compartmental/model.py
+++ b/src/laser/measles/compartmental/model.py
@@ -38,9 +38,8 @@ class CompartmentalModel(BaseLaserModel):
         name (str): Display name for log messages.  Defaults to
             ``"compartmental"``.
 
-    **Example:**
+    Examples:
 
-        ```python
         import laser.measles as lm
         from laser.measles.compartmental.components import (
             InfectionSeedingProcess,
@@ -51,7 +50,6 @@ class CompartmentalModel(BaseLaserModel):
         model = lm.CompartmentalModel(scenario=df, params=params)
         model.components = [InfectionSeedingProcess, InfectionProcess]
         model.run()
-        ```
     """
 
     # Specify the scenario wrapper class for auto-wrapping DataFrames
@@ -151,9 +149,8 @@ class CompartmentalModel(BaseLaserModel):
                 [`CompartmentalModel`][laser.measles.compartmental.model.CompartmentalModel]
                 ready for ``model.run()``.
 
-        **Example:**
+        Examples:
 
-            ```python
             import laser.measles as lm
             from laser.measles.compartmental.components import InfectionProcess
 
@@ -162,7 +159,6 @@ class CompartmentalModel(BaseLaserModel):
                 "checkpoint.h5", params2, components=[InfectionProcess]
             )
             model2.run()
-            ```
         """
         from laser.measles.compartmental.snapshot import load_snapshot  # noqa: PLC0415
 

--- a/src/laser/measles/compartmental/params.py
+++ b/src/laser/measles/compartmental/params.py
@@ -23,11 +23,9 @@ class CompartmentalParams(BaseModelParams):
             Default: ``"2000-01"``.
         verbose: Print detailed logging.  Default: ``False``.
 
-    **Example:**
+    Examples:
 
-        ```python
         params = CompartmentalParams(num_ticks=365, seed=42, start_time="2000-01")
-        ```
     """
 
     @property

--- a/src/laser/measles/compartmental/snapshot.py
+++ b/src/laser/measles/compartmental/snapshot.py
@@ -68,9 +68,8 @@ def save_snapshot(
         path: Destination HDF5 file path (created or overwritten).
         verbose: Print a progress summary.
 
-    **Example:**
+    Examples:
 
-        ```python
         import laser.measles as lm
         from laser.measles.compartmental import save_snapshot
         from laser.measles.compartmental.components import (
@@ -84,7 +83,6 @@ def save_snapshot(
         model.run()
 
         save_snapshot(model, "checkpoint.h5")
-        ```
     """
     path = Path(path)
 
@@ -160,9 +158,8 @@ def load_snapshot(
             [`CompartmentalModel`][laser.measles.compartmental.model.CompartmentalModel]
             instance.  Call ``model.run()`` to continue the simulation.
 
-    **Example:**
+    Examples:
 
-        ```python
         import laser.measles as lm
         from laser.measles.compartmental import load_snapshot
         from laser.measles.compartmental.components import InfectionProcess
@@ -172,7 +169,6 @@ def load_snapshot(
             "checkpoint.h5", params2, components=[InfectionProcess]
         )
         model2.run()
-        ```
     """
     from laser.measles.compartmental.model import CompartmentalModel  # noqa: PLC0415
 

--- a/src/laser/measles/components/base.py
+++ b/src/laser/measles/components/base.py
@@ -18,9 +18,8 @@ class BaseVitalDynamicsProcess(BasePhase):
     [`ABMModel`][laser.measles.abm.model.ABMModel]).
 
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -30,7 +29,6 @@ class BaseVitalDynamicsProcess(BasePhase):
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.add_component(create_component(components.VitalDynamicsProcess, components.VitalDynamicsParams()))
-        ```
     """
 
     @abstractmethod

--- a/src/laser/measles/components/base_case_surveillance.py
+++ b/src/laser/measles/components/base_case_surveillance.py
@@ -28,14 +28,11 @@ class BaseCaseSurveillanceParams(BaseModel):
         aggregate_cases: Whether to aggregate cases by geographic level.
         aggregation_level: Number of levels to use for aggregation (e.g., 2 for country:state:lga).
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.biweekly.components.tracker_case_surveillance import CaseSurveillanceParams
 
         params = CaseSurveillanceParams()
-        ```
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -80,10 +77,8 @@ class BaseCaseSurveillanceTracker(BasePhase):
         model: The simulation model containing nodes, states, and parameters.
         params: Component-specific parameters. If None, will use default parameters.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -93,7 +88,6 @@ class BaseCaseSurveillanceTracker(BasePhase):
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.add_component(create_component(components.CaseSurveillanceTracker, components.CaseSurveillanceParams()))
-        ```
     """
 
     def __init__(self, model: BaseLaserModel, params: BaseCaseSurveillanceParams | None = None) -> None:

--- a/src/laser/measles/components/base_constant_pop.py
+++ b/src/laser/measles/components/base_constant_pop.py
@@ -13,13 +13,11 @@ from laser.measles.components import BaseVitalDynamicsProcess
 class BaseConstantPopParams(BaseVitalDynamicsParams):
     """Parameters specific to the births process component.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.biweekly.components.process_constant_pop import ConstantPopParams
 
         params = ConstantPopParams(crude_birth_rate=20)
-        ```
     """
 
     crude_birth_rate: float = Field(default=20, description="Crude birth rate per 1000 people per year", ge=0.0)
@@ -35,15 +33,12 @@ class BaseConstantPopProcess(BaseVitalDynamicsProcess):
     A component to handle the birth events in a model with constant population - that is, births == deaths.
 
     Attributes:
-
         model: The model instance containing population and parameters.
         initializers (list): List of initializers to be called on birth events.
         metrics (DataFrame): DataFrame to holding timing metrics for initializers.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -53,7 +48,6 @@ class BaseConstantPopProcess(BaseVitalDynamicsProcess):
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.add_component(create_component(components.ConstantPopProcess, components.ConstantPopParams()))
-        ```
     """
 
     def __init__(self, model: BaseLaserModel, params: BaseConstantPopParams | None = None):
@@ -61,7 +55,6 @@ class BaseConstantPopProcess(BaseVitalDynamicsProcess):
         Initialize the Births component.
 
         Parameters:
-
             model (object): The model object which must have a `population` attribute.
             params (BirthsParams, optional): Component parameters. If None, uses model.params.
 
@@ -78,17 +71,15 @@ class BaseConstantPopProcess(BaseVitalDynamicsProcess):
         Adds new agents to each patch based on expected daily births calculated from CBR. Calls each of the registered initializers for the newborns.
 
         Args:
-
             model: The simulation model containing patches, population, and parameters.
             tick: The current time step in the simulation.
 
         Returns:
-
             None
 
         This method performs the following steps:
 
-            1. Draw a random set of indices, or size size "number of births"  from the population,
+        1. Draw a random set of indices, or size size "number of births"  from the population,
         """
         raise NotImplementedError("This method should be implemented in the subclass.")
 

--- a/src/laser/measles/components/base_infection.py
+++ b/src/laser/measles/components/base_infection.py
@@ -11,13 +11,11 @@ from laser.measles.base import BasePhase
 class BaseInfectionParams(BaseModel):
     """Parameters specific to the infection process component.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.biweekly.components.process_infection import InfectionParams
 
         params = InfectionParams(beta=0.57, seasonality=0.2)
-        ```
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -44,9 +42,8 @@ class BaseInfectionParams(BaseModel):
 class BaseInfectionProcess(BasePhase, ABC):
     """Base class for infection (transmission and disease progression).
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -56,5 +53,4 @@ class BaseInfectionProcess(BasePhase, ABC):
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.add_component(create_component(components.InfectionProcess, components.InfectionParams(beta=0.57)))
-        ```
     """

--- a/src/laser/measles/components/base_infection_seeding.py
+++ b/src/laser/measles/components/base_infection_seeding.py
@@ -19,13 +19,11 @@ from laser.measles.utils import cast_type
 class BaseInfectionSeedingParams(BaseModel):
     """Parameters for the infection seeding component.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.biweekly.components.process_infection_seeding import InfectionSeedingParams
 
         params = InfectionSeedingParams()
-        ```
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -91,16 +89,13 @@ class BaseInfectionSeedingProcess(BaseComponent):
     The seeding occurs during the initialize() phase, after equilibrium states are set
     but before the simulation begins.
 
-    Parameters
-    ----------
-    model : BaseLaserModel
-        The compartmental model instance
-    params : Optional[InfectionSeedingParams], default=None
-        Component-specific parameters. If None, will use default parameters
+    Args:
+        model (BaseLaserModel): The compartmental model instance
+        params (Optional[InfectionSeedingParams], default=None): Component-specific parameters. If None, will use default parameters
 
-    Examples
-    --------
-    # Seed 1 infection in largest patch (default)
+    Examples:
+
+        # Seed 1 infection in largest patch (default)
     seeding_params = InfectionSeedingParams()
 
     # Seed 5 infections in largest patch

--- a/src/laser/measles/components/base_initialize_equilibrium_states.py
+++ b/src/laser/measles/components/base_initialize_equilibrium_states.py
@@ -16,14 +16,11 @@ class BaseInitializeEquilibriumStatesParams(BaseModel):
     """
     Parameters for the InitializeEquilibriumStatesProcess.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.biweekly.components.process_initialize_equilibrium_states import InitializeEquilibriumStatesParams
 
         params = InitializeEquilibriumStatesParams()
-        ```
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -45,10 +42,8 @@ class BaseInitializeEquilibriumStatesProcess(BasePhase):
     """
     Initialize S, R states of the population in each of the model states by rough equilibrium of R0.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -58,7 +53,6 @@ class BaseInitializeEquilibriumStatesProcess(BasePhase):
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.add_component(create_component(components.InitializeEquilibriumStatesProcess, components.InitializeEquilibriumStatesParams()))
-        ```
     """
 
     def __init__(self, model: BaseLaserModel, params: BaseInitializeEquilibriumStatesParams | None = None):

--- a/src/laser/measles/components/base_tracker.py
+++ b/src/laser/measles/components/base_tracker.py
@@ -14,13 +14,11 @@ from ..base import BaseComponent
 class BaseTrackerParams(BaseModel):
     """Common parameters for tracker components.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.biweekly.components.tracker_state import StateTrackerParams
 
         params = StateTrackerParams(track_states=True, output_frequency=1)
-        ```
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -35,9 +33,8 @@ class BaseTrackerParams(BaseModel):
 class BaseTracker(BaseComponent, ABC):
     """Abstract base class for tracker components.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -47,7 +44,6 @@ class BaseTracker(BaseComponent, ABC):
         params = BiweeklyParams(num_ticks=52, seed=42, start_time="2000-01")
         model = BiweeklyModel(scenario, params)
         model.add_component(create_component(components.StateTracker, components.StateTrackerParams()))
-        ```
     """
 
     def __init__(self, model, params: BaseTrackerParams | None = None):

--- a/src/laser/measles/components/base_tracker_state.py
+++ b/src/laser/measles/components/base_tracker_state.py
@@ -34,14 +34,11 @@ class BaseStateTrackerParams(BaseModel):
             The ``patch_id`` column in ``get_dataframe()`` matches the ``id`` column of the
             scenario DataFrame at the requested hierarchy level.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.biweekly.components.tracker_state import StateTrackerParams
 
         params = StateTrackerParams()
-        ```
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -74,10 +71,8 @@ class BaseStateTracker(BasePhase):
         model: The simulation model containing nodes, states, and parameters.
         params: Component-specific parameters. If None, will use default parameters.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.scenarios.synthetic import single_patch_scenario
         from laser.measles.biweekly import BiweeklyModel, BiweeklyParams
         from laser.measles.biweekly import components
@@ -89,7 +84,6 @@ class BaseStateTracker(BasePhase):
         model.add_component(create_component(components.StateTracker, components.StateTrackerParams()))
         model.run()
         state_tracker = model.get_component("StateTracker")
-        ```
     """
 
     def __init__(self, model: BaseLaserModel, params: BaseStateTrackerParams | None = None) -> None:
@@ -197,7 +191,8 @@ class BaseStateTracker(BasePhase):
             None: This function uses a generator to yield control back to the caller.
             If used directly (not as a generator), it will show the plot immediately.
 
-        Example:
+        Examples:
+
             # Use as a generator (for model.visualize()):
             for _ in tracker.plot():
                 plt.show()

--- a/src/laser/measles/components/base_transmission.py
+++ b/src/laser/measles/components/base_transmission.py
@@ -57,13 +57,11 @@ class BaseTransmission(BasePhase, ABC):
             Uses [`BaseTransmissionParams`][laser.measles.components.base_transmission.BaseTransmissionParams]
             defaults if ``None``.
 
-    **Example:**
+    Examples:
 
-        ```python
         # Transmission components are typically added via the model's component list:
         from laser.measles.compartmental.components import InfectionProcess
         model.add_component(InfectionProcess)
-        ```
     """
 
     def __init__(self, model: BaseLaserModel, params: BaseTransmissionParams | None = None):

--- a/src/laser/measles/components/base_vital_dynamics.py
+++ b/src/laser/measles/components/base_vital_dynamics.py
@@ -16,13 +16,11 @@ ModelType = TypeVar("ModelType")
 class BaseVitalDynamicsParams(BaseModel):
     """Parameters specific to vital dynamics.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.biweekly.components.process_vital_dynamics import VitalDynamicsParams
 
         params = VitalDynamicsParams()
-        ```
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -44,8 +42,7 @@ class BaseVitalDynamicsProcess(BasePhase, ABC):
     This phase handles the simulation of births and deaths in the population model along
     with routine vaccination (MCV1).
 
-    .. warning::
-
+    Warning:
         The ``mcv1`` scenario parameter **only vaccinates newborns** at each tick.
         It does **not** immunize the existing population. In short simulations
         (< 5 years), this produces negligible population-level immunity changes.
@@ -60,18 +57,14 @@ class BaseVitalDynamicsProcess(BasePhase, ABC):
         See the *Vaccination Modeling* tutorial (``docs/tutorials/tut_vaccination.py``)
         for detailed examples of each approach.
 
-    Parameters
-    ----------
-    model : object
-        The simulation model containing nodes, states, and parameters
-    params : VitalDynamicsParams | None, default=None
-        Component-specific parameters. If None, will use default parameters
+    Args:
+        model (object): The simulation model containing nodes, states, and parameters
+        params (VitalDynamicsParams | None, default=None): Component-specific parameters. If None, will use default parameters
 
-    Notes
-    -----
-    - Birth rates are calculated per tick
-    - MCV1 coverage is applied only to newborns; expect 5-10+ years of simulation
-      time before routine immunization significantly shifts population-level immunity
+    Notes:
+        - Birth rates are calculated per tick
+        - MCV1 coverage is applied only to newborns; expect 5-10+ years of simulation
+          time before routine immunization significantly shifts population-level immunity
     """
 
     def __init__(self, model, params: BaseVitalDynamicsParams | None = None) -> None:

--- a/src/laser/measles/components/results_writer.py
+++ b/src/laser/measles/components/results_writer.py
@@ -78,7 +78,7 @@ class ResultsWriter(BaseComponent):
             peak_infectious_per_group:  list[int]   | None
             final_state_per_group:      dict[str, list[int]] | None
 
-    Example::
+    Examples:
 
         from laser.measles.components import ResultsWriter, ResultsWriterParams
         from laser.measles.components import create_component
@@ -125,7 +125,7 @@ class ResultsWriter(BaseComponent):
     def _build(self, model: BaseLaserModel) -> dict:
         """Construct the results dict from the model's StateTracker.
 
-        Internal helper for :meth:`finalize`. Private by convention —
+        Internal helper for [`finalize`][laser.measles.components.results_writer.ResultsWriter.finalize]. Private by convention —
         external callers should add ``ResultsWriter`` to
         ``model.components`` rather than calling this directly.
 

--- a/src/laser/measles/components/utils.py
+++ b/src/laser/measles/components/utils.py
@@ -37,9 +37,9 @@ def component(cls: type[T] | None = None, **default_params: Any) -> Callable[[ty
         The decorated class (with ``create`` attached), or a decorator
             function if ``cls`` is ``None``.
 
-    Examples
-    --------
-    Basic usage:
+    Examples:
+
+        Basic usage:
 
     >>> @component
     ... class MyComponent(BaseComponent):
@@ -98,43 +98,34 @@ def create_component(component_class: type[T], params: type[B] | None = None) ->
     This function creates a callable object that will instantiate the component
     with the given parameters when called by the model.
 
-    Parameters
-    ----------
-    component_class : Type[BaseComponent]
-        The component class to instantiate
-    params : BaseModel, optional
-        Parameter object to pass to the component constructor as ``params=...``.
+    Args:
+        component_class (Type[BaseComponent]): The component class to instantiate
+        params (BaseModel, optional): Parameter object to pass to the component constructor as ``params=...``.
 
-    Returns
-    -------
-    Callable[[Any], BaseComponent]
-        A single-argument factory: when called by the model with the model
-        instance, it returns ``component_class(model, params=params)``.
+    Returns:
+        Callable[[Any], BaseComponent]: A single-argument factory: when called by the model with the model
+            instance, it returns ``component_class(model, params=params)``.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles import create_component
         from laser.measles.compartmental.components import InfectionProcess, InfectionParams
 
         model.components = [
             create_component(InfectionProcess, InfectionParams(beta=0.8)),
         ]
-        ```
     """
 
     class ComponentFactory:
         """Callable wrapper that pairs a component class with its parameters.
 
-        **Example:**
+        Examples:
 
-            ```python
             from laser.measles.components.utils import ComponentFactory
             from laser.measles.biweekly.components.process_infection import InfectionProcess, InfectionParams
 
             factory = ComponentFactory()
             component = factory.create(InfectionProcess, InfectionParams(beta=0.57), model=model)
-            ```
         """
 
         def __init__(self, component_class: type[T], params: BaseModel | None = None):

--- a/src/laser/measles/demographics/admin_shapefile.py
+++ b/src/laser/measles/demographics/admin_shapefile.py
@@ -19,15 +19,12 @@ class AdminShapefile(BaseShapefile):
         admin_level: Admin level of the shapefile.
         dotname_fields: List of fields to use for dotname. e.g., ["ADMIN0", "ADMIN1", "ADMIN2"]
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.demographics.admin_shapefile import AdminShapefile
 
         shapefile = AdminShapefile("path/to/shapefile.shp")
         df = shapefile.get_dataframe()
-        ```
     """
 
     admin_level: int | None = None

--- a/src/laser/measles/demographics/base.py
+++ b/src/laser/measles/demographics/base.py
@@ -16,17 +16,14 @@ class DemographicsGeneratorProtocol(Protocol):
     See [`RasterPatchGenerator`][laser.measles.demographics.raster_patch.RasterPatchGenerator]
     for the primary implementation.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.demographics.raster_patch import RasterPatchGenerator, RasterPatchParams
         from laser.measles.demographics.gadm import GADMShapefile
 
         shapefile = GADMShapefile("NGA")
         generator = RasterPatchGenerator(shapefile, RasterPatchParams(admin_level=2))
         scenario = generator.generate_demographics()
-        ```
     """
 
     def generate_population(self) -> pl.DataFrame:
@@ -45,14 +42,12 @@ class DemographicsGeneratorProtocol(Protocol):
 class ShapefileProtocol(Protocol):
     """Protocol for shapefile readers used by the demographics pipeline.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.demographics.gadm import GADMShapefile
 
         shapefile = GADMShapefile("NGA")  # Nigeria
         df = shapefile.get_dataframe()
-        ```
     """
 
     def add_dotname(self) -> None:
@@ -73,15 +68,12 @@ class BaseShapefile(BaseModel):
     Attributes:
         shapefile: Path to a ``.shp`` file.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.demographics.gadm import GADMShapefile
 
         shapefile = GADMShapefile("NGA")
         df = shapefile.get_dataframe()
-        ```
     """
 
     shapefile: Path

--- a/src/laser/measles/demographics/gadm.py
+++ b/src/laser/measles/demographics/gadm.py
@@ -33,12 +33,10 @@ class GADMShapefile(AdminShapefile):
     [`download`][laser.measles.demographics.gadm.GADMShapefile.download] to
     fetch a country's boundaries, or construct directly from a local file.
 
-    **Example:**
+    Examples:
 
-        ```python
         gadm = GADMShapefile.download("NGA", admin_level=2, directory="./data")
         df = gadm.get_dataframe()
-        ```
     """
 
     @model_validator(mode="after")

--- a/src/laser/measles/demographics/raster_patch.py
+++ b/src/laser/measles/demographics/raster_patch.py
@@ -40,14 +40,11 @@ class RasterPatchParams(BaseModel):
         mcv1_raster: Path to a MCV1 coverage raster (GeoTIFF).
         mcv2_raster: Path to a MCV2 coverage raster (GeoTIFF).
 
+    Examples:
 
-    **Example:**
-
-        ```python
         from laser.measles.demographics.raster_patch import RasterPatchParams
 
         params = RasterPatchParams(admin_level=2)
-        ```
     """
 
     id: str = Field(..., description="Unique identifier for the scenario")
@@ -83,9 +80,8 @@ class RasterPatchGenerator:
             specifying inputs.
         verbose: Print progress messages.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.demographics.raster_patch import (
             RasterPatchGenerator, RasterPatchParams,
         )
@@ -99,7 +95,6 @@ class RasterPatchGenerator:
         )
         generator = RasterPatchGenerator(config)
         scenario_df = generator.generate_demographics()
-        ```
     """
 
     def __init__(self, config: RasterPatchParams, verbose: bool = True):

--- a/src/laser/measles/demographics/wpp.py
+++ b/src/laser/measles/demographics/wpp.py
@@ -29,7 +29,8 @@ class WPP:
         age_vec (np.ndarray): Age vector in days, representing age bins.
         pyramid_spline: Interpolating spline for population pyramid data.
 
-    Example:
+    Examples:
+
         >>> wpp = WPP("USA")
         >>> pyramid_2020 = wpp.get_population_pyramid(2020)
         >>> print(f"Population pyramid shape: {pyramid_2020.shape}")
@@ -79,7 +80,8 @@ class WPP:
             AssertionError: If the requested year is outside the available
                 data range (before first year or after last year).
 
-        Example:
+        Examples:
+
             >>> wpp = WPP("USA")
             >>> pyramid_2020 = wpp.get_population_pyramid(2020)
             >>> print(f"Age groups: {len(pyramid_2020)}")

--- a/src/laser/measles/migration.py
+++ b/src/laser/measles/migration.py
@@ -55,9 +55,8 @@ def get_diffusion_matrix(df: pl.DataFrame, scale: float, func: Callable, f_kwarg
         Row-stochastic diffusion matrix of shape ``(N, N)`` where ``N`` is
             the number of patches.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.migration import get_diffusion_matrix, pairwise_haversine
         from laser.core.migration import gravity
 
@@ -69,7 +68,6 @@ def get_diffusion_matrix(df: pl.DataFrame, scale: float, func: Callable, f_kwarg
             f_kwargs=dict(populations=scenario["pop"].to_numpy(),
                           distances=distances, k=1.0, a=1.0, b=1.0, c=2.0),
         )
-        ```
     """
     if len(df) == 1:
         return np.ones((1, 1))

--- a/src/laser/measles/mixing/base.py
+++ b/src/laser/measles/mixing/base.py
@@ -26,16 +26,14 @@ class BaseMixing(ABC):
             (the model sets it automatically).
         params: Pydantic parameter object specific to the mixing model.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.mixing.gravity import GravityMixing, GravityParams
 
         # Construct a mixer — scenario is set automatically by the model
         mixer = GravityMixing(params=GravityParams(k=0.01, c=2.0))
         migration = mixer.migration_matrix  # (N, N) patch-to-patch travel
         mixing = mixer.mixing_matrix        # rows sum to 1 (includes self-mixing)
-        ```
     """
 
     def __init__(self, scenario: pl.DataFrame | None, params: BaseModel | None):

--- a/src/laser/measles/mixing/competing_destinations.py
+++ b/src/laser/measles/mixing/competing_destinations.py
@@ -21,13 +21,11 @@ class CompetingDestinationsParams(BaseModel):
         delta: Destination-competition exponent — negative values
             penalise destinations with many nearby competitors.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.mixing.competing_destinations import CompetingDestinationsParams
 
         params = CompetingDestinationsParams(a=1.0, b=1.0, c=1.5, k=0.01, delta=-0.5)
-        ```
     """
 
     a: float = Field(default=1.0, description="Population source scale parameter", ge=1.0)
@@ -55,9 +53,8 @@ class CompetingDestinationsMixing(BaseMixing):
             model will set it automatically.
         params (CompetingDestinationsParams | None): Model parameters.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.mixing.competing_destinations import (
             CompetingDestinationsMixing, CompetingDestinationsParams,
         )
@@ -69,7 +66,6 @@ class CompetingDestinationsMixing(BaseMixing):
         )
         infection_params = components.InfectionParams(beta=0.8, mixer=mixer)
         model.add_component(create_component(components.InfectionProcess, infection_params))
-        ```
     """
 
     def __init__(self, scenario: pl.DataFrame | None = None, params: CompetingDestinationsParams | None = None):

--- a/src/laser/measles/mixing/gravity.py
+++ b/src/laser/measles/mixing/gravity.py
@@ -20,13 +20,11 @@ class GravityParams(BaseModel):
         c: Distance decay exponent - larger values suppress long-distance travel.
         k: Average trip probability (scales the overall matrix).
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.mixing.gravity import GravityParams
 
         params = GravityParams(a=1.0, b=1.0, c=2.0, k=0.01)
-        ```
     """
 
     a: float = Field(default=1.0, description="Population source scale parameter", ge=1.0)
@@ -55,9 +53,8 @@ class GravityMixing(BaseMixing):
             [`GravityParams`][laser.measles.mixing.gravity.GravityParams]
             defaults if ``None``.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.mixing.gravity import GravityMixing, GravityParams
         from laser.measles.compartmental import components
         from laser.measles import create_component
@@ -65,7 +62,6 @@ class GravityMixing(BaseMixing):
         mixer = GravityMixing(params=GravityParams(a=1.0, b=1.0, c=2.0, k=0.01))
         infection_params = components.InfectionParams(beta=0.8, mixer=mixer)
         model.components = [create_component(components.InfectionProcess, infection_params)]
-        ```
     """
 
     def __init__(self, scenario: pl.DataFrame | None = None, params: GravityParams | None = None):

--- a/src/laser/measles/mixing/radiation.py
+++ b/src/laser/measles/mixing/radiation.py
@@ -14,13 +14,11 @@ class RadiationParams(BaseModel):
         include_home: Whether to include home in the migration matrix
         k: Scale parameter (avg trip probability)
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.mixing.radiation import RadiationParams
 
         params = RadiationParams(k=0.02, include_home=True)
-        ```
     """
 
     include_home: bool = Field(default=True, description="Whether to include home in the migration matrix")
@@ -46,9 +44,8 @@ class RadiationMixing(BaseMixing):
             [`RadiationParams`][laser.measles.mixing.radiation.RadiationParams]
             defaults if ``None``.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.mixing.radiation import RadiationMixing, RadiationParams
         from laser.measles.compartmental import components
         from laser.measles import create_component
@@ -56,10 +53,9 @@ class RadiationMixing(BaseMixing):
         mixer = RadiationMixing(params=RadiationParams(k=0.01))
         infection_params = components.InfectionParams(beta=0.8, mixer=mixer)
         model.add_component(create_component(components.InfectionProcess, infection_params))
-        ```
 
     The ``include_home`` and ``k`` model parameters are configured via
-    :class:`RadiationParams`.
+    [`RadiationParams`][laser.measles.mixing.radiation.RadiationParams].
     """
 
     def __init__(self, scenario: pl.DataFrame | None = None, params: RadiationParams | None = None):

--- a/src/laser/measles/mixing/stouffer.py
+++ b/src/laser/measles/mixing/stouffer.py
@@ -14,13 +14,11 @@ class StoufferParams(BaseModel):
         include_home: Whether to include home in the migration matrix
         k: Scale parameter (avg trip probability)
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.mixing.stouffer import StoufferParams
 
         params = StoufferParams(k=0.02, include_home=True, a=1.0, b=1.0)
-        ```
     """
 
     include_home: bool = Field(default=True, description="Whether to include home in the migration matrix")
@@ -44,9 +42,8 @@ class StoufferMixing(BaseMixing):
             [`StoufferParams`][laser.measles.mixing.stouffer.StoufferParams]
             defaults if ``None``.
 
-    **Example:**
+    Examples:
 
-        ```python
         from laser.measles.mixing.stouffer import StoufferMixing, StoufferParams
         from laser.measles.compartmental import components
         from laser.measles import create_component
@@ -54,9 +51,8 @@ class StoufferMixing(BaseMixing):
         mixer = StoufferMixing(params=StoufferParams(k=0.01))
         infection_params = components.InfectionParams(beta=0.8, mixer=mixer)
         model.add_component(create_component(components.InfectionProcess, infection_params))
-        ```
 
-    The ``include_home`` model parameter is configured via :class:`StoufferParams`.
+    The ``include_home`` model parameter is configured via [`StoufferParams`][laser.measles.mixing.stouffer.StoufferParams].
     """
 
     def __init__(self, scenario: pl.DataFrame | None = None, params: StoufferParams | None = None):

--- a/src/laser/measles/scenarios/synthetic.py
+++ b/src/laser/measles/scenarios/synthetic.py
@@ -1,57 +1,47 @@
 """Synthetic scenario builders for laser-measles models.
 
-Overview
---------
-Every laser-measles model (ABM, Biweekly, Compartmental) requires a **scenario**: a
-Polars DataFrame with one row per geographic patch.  This module provides ready-made
-scenario builders for testing and development.  For production use, supply your own
-DataFrame following the schema below.
+Overview:
+    Every laser-measles model (ABM, Biweekly, Compartmental) requires a **scenario**: a
+    Polars DataFrame with one row per geographic patch.  This module provides ready-made
+    scenario builders for testing and development.  For production use, supply your own
+    DataFrame following the schema below.
 
-Correct import paths
---------------------
-Import the module::
+Correct import paths:
+    Import the module:
 
-    from laser.measles.scenarios import synthetic
-    scenario = synthetic.single_patch_scenario(population=50_000, mcv1_coverage=0.8)
 
-Or import individual functions directly::
+        from laser.measles.scenarios import synthetic
+        scenario = synthetic.single_patch_scenario(population=50_000, mcv1_coverage=0.8)
 
-    from laser.measles.scenarios.synthetic import single_patch_scenario, two_patch_scenario
-    from laser.measles.scenarios import single_patch_scenario   # also re-exported here
 
-**NEVER** write ``import laser_measles`` or ``from laser_measles import ...``.
-The package is always ``laser.measles`` (dot, not underscore).
+    Or import individual functions directly:
 
-Scenario DataFrame schema
---------------------------
-All scenario DataFrames **must** contain at least these five columns:
+        from laser.measles.scenarios.synthetic import single_patch_scenario, two_patch_scenario
+        from laser.measles.scenarios import single_patch_scenario   # also re-exported here
 
-+--------+----------+--------------------------------------------------+
-| Column | Dtype    | Description                                      |
-+========+==========+==================================================+
-| id     | Utf8/str | Unique string identifier for the patch.          |
-|        |          | Examples: ``"patch_0"``, ``"cluster_1:node_3"``  |
-+--------+----------+--------------------------------------------------+
-| pop    | Int64    | Total population of the patch (integer).         |
-+--------+----------+--------------------------------------------------+
-| lat    | Float64  | Latitude of the patch centroid (degrees).        |
-+--------+----------+--------------------------------------------------+
-| lon    | Float64  | Longitude of the patch centroid (degrees).       |
-+--------+----------+--------------------------------------------------+
-| mcv1   | Float64  | Routine MCV1 vaccination coverage, 0.0-1.0.      |
-+--------+----------+--------------------------------------------------+
+    **NEVER** write ``import laser_measles`` or ``from laser_measles import ...``.
+    The package is always ``laser.measles`` (dot, not underscore).
 
-Critical schema notes:
+Scenario DataFrame schema:
+    All scenario DataFrames **must** contain at least these five columns:
 
-* ``id`` **must be a string** (``pl.Utf8``).  Integer IDs will fail validation.
-* ``pop`` **must be named** ``pop``, **not** ``population``.
-* ``mcv1`` **must be present** even when vaccination is irrelevant to your analysis
-  (use ``0.0`` as a placeholder).
-* Extra columns are allowed and are ignored by the model.
+    | Column | Dtype    | Description                                                                          |
+    |--------|----------|--------------------------------------------------------------------------------------|
+    | `id`   | Utf8/str | Unique string identifier for the patch. Examples: `"patch_0"`, `"cluster_1:node_3"`. |
+    | `pop`  | Int64    | Total population of the patch (integer).                                             |
+    | `lat`  | Float64  | Latitude of the patch centroid (degrees).                                            |
+    | `lon`  | Float64  | Longitude of the patch centroid (degrees).                                           |
+    | `mcv1` | Float64  | Routine MCV1 vaccination coverage, 0.0-1.0.                                          |
 
-Building a scenario by hand (no helper function needed)
--------------------------------------------------------
-::
+    Critical schema notes:
+
+    * ``id`` **must be a string** (``pl.Utf8``).  Integer IDs will fail validation.
+    * ``pop`` **must be named** ``pop``, **not** ``population``.
+    * ``mcv1`` **must be present** even when vaccination is irrelevant to your analysis
+      (use ``0.0`` as a placeholder).
+    * Extra columns are allowed and are ignored by the model.
+
+Building a scenario by hand (no helper function needed):
 
     import polars as pl
 
@@ -63,46 +53,45 @@ Building a scenario by hand (no helper function needed)
         "mcv1": [0.85,      0.70,      0.60],
     })
 
-Available helper functions
----------------------------
-single_patch_scenario(population, mcv1_coverage)
-    One patch.  Useful for the simplest possible "hello world" run::
+Available helper functions:
+    `single_patch_scenario(population, mcv1_coverage)` — one patch. Useful for the
+    simplest possible "hello world" run:
 
         from laser.measles.scenarios.synthetic import single_patch_scenario
         scenario = single_patch_scenario(population=10_000, mcv1_coverage=0.0)
 
-two_patch_scenario(population, mcv1_coverage)
-    Two patches; the second patch has half the population of the first::
+
+    `two_patch_scenario(population, mcv1_coverage)` — two patches; the second patch has
+    half the population of the first:
 
         from laser.measles.scenarios.synthetic import two_patch_scenario
         scenario = two_patch_scenario(population=100_000, mcv1_coverage=0.8)
 
-two_cluster_scenario(seed, n_nodes_per_cluster, ...)
-    100 patches arranged in two geographic clusters, with randomised populations
-    and MCV1 coverage in a configurable range.  Good for spatial spread studies::
+    `two_cluster_scenario(seed, n_nodes_per_cluster, ...)` — 100 patches arranged in two
+    geographic clusters, with randomised populations and MCV1 coverage in a configurable
+    range. Good for spatial spread studies:
 
         from laser.measles.scenarios.synthetic import two_cluster_scenario
         scenario = two_cluster_scenario(seed=42, n_nodes_per_cluster=50)
 
-satellites_scenario(core_population, satellite_population, n_towns, ...)
-    One large central city surrounded by smaller satellite towns — a classic
-    city-and-hinterland structure::
+    `satellites_scenario(core_population, satellite_population, n_towns, ...)` — one large
+    central city surrounded by smaller satellite towns — a classic city-and-hinterland
+    structure:
 
         from laser.measles.scenarios.synthetic import satellites_scenario
         scenario = satellites_scenario(core_population=500_000, n_towns=30, mcv1=0.5)
 
-Connecting a scenario to a model
----------------------------------
-Pass the DataFrame directly as the first argument to any model constructor::
+Connecting a scenario to a model:
+    Pass the DataFrame directly as the first argument to any model constructor:
 
-    from laser.measles.abm import ABMModel, ABMParams
-    from laser.measles.scenarios.synthetic import single_patch_scenario
+        from laser.measles.abm import ABMModel, ABMParams
+        from laser.measles.scenarios.synthetic import single_patch_scenario
 
-    scenario = single_patch_scenario(population=50_000, mcv1_coverage=0.85)
-    params   = ABMParams(num_ticks=365, seed=42, start_time="2000-01")
-    model    = ABMModel(scenario, params)
+        scenario = single_patch_scenario(population=50_000, mcv1_coverage=0.85)
+        params   = ABMParams(num_ticks=365, seed=42, start_time="2000-01")
+        model    = ABMModel(scenario, params)
 
-The same pattern applies to ``BiweeklyModel`` and ``CompartmentalModel``.
+    The same pattern applies to ``BiweeklyModel`` and ``CompartmentalModel``.
 """
 
 import numpy as np

--- a/src/laser/measles/utils.py
+++ b/src/laser/measles/utils.py
@@ -199,7 +199,8 @@ class StateArray(np.ndarray):
     while maintaining full numpy array functionality and backward compatibility with
     numeric indexing (e.g., states[0], states[1]).
 
-    Example:
+    Examples:
+
         >>> states = StateArray(source_array=np.zeros((3, 100)), state_names=["S", "I", "R"], state_axis=0)
         >>> states.S[0] = 1000  # Set susceptible population in patch 0
         >>> prevalence = states.I / states.sum(axis=0)  # Calculate prevalence

--- a/src/laser/measles/wrapper.py
+++ b/src/laser/measles/wrapper.py
@@ -20,13 +20,10 @@ class PrettyComponentsList(list):
     This class maintains full list functionality while adding a formatted
     display similar to the LaserFrame wrapper style.
 
+    Examples:
 
-    **Example:**
-
-        ```python
         # PrettyComponentsList wraps model.components for readable display
         model.components  # prints a formatted table of all components
-        ```
     """
 
     def __str__(self) -> str:
@@ -78,7 +75,7 @@ class PrettyLaserFrameWrapper:
     This wrapper maintains full compatibility with the underlying LaserFrame while
     adding a clean and snazzy print method that displays all properties.
 
-    Example:
+    Examples:
 
         >>> lf = LaserFrame(capacity=1000)
         >>> lf.add_scalar_property("age", dtype=np.uint8)
@@ -254,7 +251,7 @@ def return_pretty_laserframe(func):
     This decorator can be used to automatically wrap LaserFrame objects returned
     by functions with enhanced printing capabilities.
 
-    Example:
+    Examples:
 
         >>> @wrapper
         ... def create_patches():
@@ -283,7 +280,7 @@ def pretty_laserframe(cls):
     This decorator can be applied to LaserFrame subclasses to automatically
     provide enhanced printing capabilities to all instances.
 
-    Example:
+    Examples:
 
         >>> @wrapper_class
         ... class PeopleLaserFrame(LaserFrame):


### PR DESCRIPTION
Updates to improve the rendering of API reference content, including:
- Updates to docstrings in many python files for malformatted text, especially for examples sections
- Update to mkdocs.yml and gen-files.py script to show only the class/function in the TOC instead of the full name to make it consistent with api-autonav
- I left the gen-files workflow in place, though it's only recommended when building an external package into the API reference too because I wasn't sure if replacing it with the simpler api-autonav config would impact JENNER. Let me know if you want me to update that too--it might speed the build up. 
