### PR TITLE
Containerize doc builds (image hosted in IDM Artifactory)

### DIFF
--- a/.github/workflows/build-jenner-doc.yml
+++ b/.github/workflows/build-jenner-doc.yml
@@ -6,15 +6,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: packages.idmod.org/docker-public/laser/laser-docs:latest
+
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - name: Install dependencies
-        run: pip install ".[docs,examples]"
+
+      - name: Install laser-measles (deps already in image)
+        run: pip install --no-deps -e .
+
       - name: Convert tutorial notebooks
         run: python scripts/convert_tutorials.py
+
       - name: Execute tutorial notebooks
         run: |
           mkdir -p dist/executed_nbs
@@ -29,10 +32,13 @@ jobs:
               --output "$base" \
               "$nb"
           done
+
       - name: Build MkDocs site
         run: mkdocs build
+
       - name: Generate combined_mkdocs.md
         run: python scripts/concat_mkdocs.py site dist/executed_nbs dist/combined_mkdocs.md
+
       - name: Upload combined_mkdocs.md
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/mkdocs-ghp.yml
+++ b/.github/workflows/mkdocs-ghp.yml
@@ -1,30 +1,34 @@
 name: MkDocs Deploy
+
 on:
   push:
     branches:
       - master
       - main
+
 permissions:
   contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    container:
+      image: packages.idmod.org/docker-public/laser/laser-docs:latest
+
     steps:
       - uses: actions/checkout@v4
-      - name: Configure Git Credentials
+
+      - name: Configure Git credentials
         run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: .cache
-          restore-keys: |
-            mkdocs-material-
-      - run: pip install ".[docs,examples]"
-      - run: python scripts/convert_tutorials.py
-      - run: mkdocs gh-deploy --force --config-file mkdocs.ci.yml
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Install laser-measles (deps already in image)
+        run: pip install --no-deps -e .
+
+      - name: Convert tutorial .py files to notebooks
+        run: python scripts/convert_tutorials.py
+
+      - name: Deploy site
+        run: mkdocs gh-deploy --force --config-file mkdocs.ci.yml

--- a/.github/workflows/mkdocs-pr.yml
+++ b/.github/workflows/mkdocs-pr.yml
@@ -2,23 +2,20 @@ name: MkDocs Build on PR
 
 on:
   pull_request:
-    branches: [master, main] # Replace with your desired branches
+    branches: [master, main]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: packages.idmod.org/docker-public/laser/laser-docs:latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-
-      - name: Install MkDocs and dependencies
-        run: pip install ".[docs,examples]"
+      - name: Install laser-measles (deps already in image)
+        run: pip install --no-deps -e .
 
       - name: Convert tutorial .py files to notebooks
         run: python scripts/convert_tutorials.py

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -30,25 +30,19 @@ jobs:
   docs-deploy:
     name: Build & deploy docs (executes notebooks)
     runs-on: ubuntu-latest
+    container:
+      image: packages.idmod.org/docker-public/laser/laser-docs:latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Configure Git Credentials
+      - name: Configure Git credentials
         run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: .cache
-          restore-keys: |
-            mkdocs-material-
-      - run: pip install ".[docs,examples]"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+      - name: Install laser-measles (deps already in image)
+        run: pip install --no-deps -e .
       - run: python scripts/convert_tutorials.py
       - run: mkdocs gh-deploy --force --config-file mkdocs.ci.yml
 
@@ -126,6 +120,8 @@ jobs:
     name: Build and upload Jenner RAG artifact
     needs: github-release
     runs-on: ubuntu-latest
+    container:
+      image: packages.idmod.org/docker-public/laser/laser-docs:latest
     permissions:
       contents: write
 
@@ -133,11 +129,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install dependencies
-        run: pip install ".[docs,examples]" bump-my-version
+      - name: Install laser-measles + release tooling (docs deps already in image)
+        run: pip install --no-deps -e . && pip install bump-my-version
       - name: Build combined markdown
         run: make docs-jenner
       - name: Upload to GitHub Release

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -45,15 +45,43 @@ RUN pip install --no-cache-dir 'pip<26' 'uv<1'
 # files) so the image is self-contained — anyone pulling the image gets the
 # same closure regardless of which checkout they're consuming it from.
 #
-# Keep this list aligned with:
+# Keep these lists aligned with:
 #   - laser-measles' [docs] / [examples] extras in pyproject.toml
 #   - docs/requirements.txt (used by the tox docs env)
+#
+# Split across four `RUN` invocations on purpose — the single 940 MB combined
+# layer trips a server-side 500 on push to the IDM Artifactory at certain
+# transfer sizes, and tooling like `crane` falls into a chunked-upload code
+# path that triggers an unrelated Artifactory NPE on the same monolithic
+# blob. Four ~150-300 MB layers push cleanly via `docker push` without
+# chunking, and rebuilds get better cache reuse when one group's pin moves.
 #
 # Key constraints:
 #   - numba>=0.60 because laser-core leaves numba unpinned, which lets uv
 #     backtrack to numba==0.53.1 (Python<=3.9 only) on a 3.12 base.
 #   - pyarrow is required by polars.DataFrame.to_pandas(), which
 #     mkdocs-jupyter triggers when rendering polars frames in tutorials.
+
+# Numeric stack — heaviest, most cache-stable (~250 MB).
+RUN uv pip install --system --no-cache \
+        'numpy>=1.26,<3' \
+        'numba>=0.60' \
+        pyarrow
+
+# Scientific stack + laser-core (~250 MB).
+RUN uv pip install --system --no-cache \
+        matplotlib \
+        polars \
+        seaborn \
+        'laser-core>=1.0.2,<2.0'
+
+# Jupyter execution (~150 MB).
+RUN uv pip install --system --no-cache \
+        notebook \
+        ipykernel \
+        jupytext
+
+# MkDocs + plugins (~100 MB) — smallest, most likely to churn.
 RUN uv pip install --system --no-cache \
         'mkdocs-material~=9.7' \
         mkdocs-include-markdown-plugin \
@@ -68,16 +96,6 @@ RUN uv pip install --system --no-cache \
         mkdocstrings-python \
         mkdocs-table-reader-plugin \
         mkdocs-exclude \
-        jupytext \
-        markdownify \
-        notebook \
-        ipykernel \
-        pyarrow \
-        matplotlib \
-        'numpy>=1.26,<3' \
-        'numba>=0.60' \
-        polars \
-        seaborn \
-        'laser-core>=1.0.2,<2.0'
+        markdownify
 
 WORKDIR /repo

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,83 @@
+# laser-measles documentation build image.
+#
+# Pins the full mkdocs-jupyter + Jupyter + scientific-python toolchain so doc
+# builds are reproducible and immune to upstream resolver drift. The image
+# does NOT contain laser-measles itself — workflows check out the repo into
+# the container at run time and `pip install --no-deps -e .` to wire up the
+# package without re-resolving any dependencies.
+#
+# Build + publish locally (GHA workflows pull from Artifactory):
+#
+#   docker login packages.idmod.org
+#   docker buildx build --platform linux/amd64 \
+#       -t packages.idmod.org/docker-public/laser/laser-docs:latest \
+#       -t packages.idmod.org/docker-public/laser/laser-docs:$(git rev-parse --short HEAD) \
+#       -f docs/Dockerfile --push .
+#
+# `--platform linux/amd64` is important: GHA runners that consume this image
+# are linux/amd64, so build for that explicitly even if your local machine
+# is something else (e.g. Apple Silicon — without --platform you'd push an
+# arm64 image and the consumer workflows would fail to pull).
+#
+# Rebuild whenever this Dockerfile, the [docs]/[examples] extras in
+# pyproject.toml, or docs/requirements.txt change.
+
+FROM python:3.12-slim
+
+# System libraries that the scientific-python wheels need at runtime, plus
+# build-essential as a fallback for any package that has no manylinux wheel.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        git \
+        libgdal-dev \
+        libgeos-dev \
+        libhdf5-dev \
+        libproj-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv handles the actual install. Pin major versions of both pip and uv so
+# resolver behavior doesn't drift between image builds.
+RUN pip install --no-cache-dir 'pip<26' 'uv<1'
+
+# Docs + notebook-execution deps. Inlined (rather than COPYing requirements
+# files) so the image is self-contained — anyone pulling the image gets the
+# same closure regardless of which checkout they're consuming it from.
+#
+# Keep this list aligned with:
+#   - laser-measles' [docs] / [examples] extras in pyproject.toml
+#   - docs/requirements.txt (used by the tox docs env)
+#
+# Key constraints:
+#   - numba>=0.60 because laser-core leaves numba unpinned, which lets uv
+#     backtrack to numba==0.53.1 (Python<=3.9 only) on a 3.12 base.
+#   - pyarrow is required by polars.DataFrame.to_pandas(), which
+#     mkdocs-jupyter triggers when rendering polars frames in tutorials.
+RUN uv pip install --system --no-cache \
+        'mkdocs-material~=9.7' \
+        mkdocs-include-markdown-plugin \
+        mkdocs-autorefs \
+        mkdocs-api-autonav \
+        mkdocs-gen-files \
+        mkdocs-literate-nav \
+        python-markdown-math \
+        pymdown-extensions \
+        mkdocs-jupyter \
+        mkdocstrings \
+        mkdocstrings-python \
+        mkdocs-table-reader-plugin \
+        mkdocs-exclude \
+        jupytext \
+        markdownify \
+        notebook \
+        ipykernel \
+        pyarrow \
+        matplotlib \
+        'numpy>=1.26,<3' \
+        'numba>=0.60' \
+        polars \
+        seaborn \
+        'laser-core>=1.0.2,<2.0'
+
+WORKDIR /repo


### PR DESCRIPTION
> **Draft.** Lift draft once the initial image is built locally and pushed to Artifactory.

## Motivation

Today every doc-build workflow does its own \`pip install ".[docs,examples]"\` into a fresh \`setup-python\` env, which means we re-resolve the full dependency tree on every run. That's how we ended up chasing the uv-on-Py3.12 backtrack to \`numba==0.53.1\` (Python ≤ 3.9 only) on #257. The install path also drifts silently as transitive deps publish new metadata.

Pinning the toolchain into an image moves the resolution work to a single, deliberate place — the image rebuild — and makes every doc workflow a thin consumer.

## Changes

**New:**
- \`docs/Dockerfile\` (83 lines) — \`python:3.12-slim\` + system libs (shapely/geopandas/h5py) + the pinned mkdocs + jupyter + scientific-python toolchain. Notable floors:
  - \`numba>=0.60\` (avoids the laser-core → unconstrained-numba → 0.53.1 backtrack that bit #257)
  - \`pyarrow\` (polars \`.to_pandas()\` needs it for mkdocs-jupyter rendering)
  - \`numpy>=1.26,<3\`
  - laser-measles itself is **not** baked in — workflows install it editable at run time so the image doesn't churn on source changes.
  - The header comment block documents the exact \`docker buildx build --platform linux/amd64 ... --push\` invocation (including the \`linux/amd64\` flag, which matters if you're building on Apple Silicon).

**Rewritten** (each loses \`setup-python\` + \`pip install ".[docs,examples]"\`, gains \`container: packages.idmod.org/docker-public/laser/laser-docs:latest\` + a one-liner \`pip install --no-deps -e .\` to register the local package):

| Workflow | Lines before → after |
|---|---|
| \`mkdocs-pr.yml\` | 27 → 19 |
| \`mkdocs-ghp.yml\` | 31 → 27 |
| \`build-jenner-doc.yml\` | 42 → 41 |
| \`publish-pypi.yml\` (\`docs-deploy\` + \`docs-jenner\` jobs) | 23+19 → 17+15 |

## Bring-up

The image is built and pushed by hand (no GHA workflow for it — adding one would just require Artifactory secrets that aren't worth setting up yet). Initial publish:

\`\`\`
docker login packages.idmod.org
docker buildx build --platform linux/amd64 \    -t packages.idmod.org/docker-public/laser/laser-docs:latest \    -t packages.idmod.org/docker-public/laser/laser-docs:\$(git rev-parse --short HEAD) \    -f docs/Dockerfile --push .
\`\`\`

After that's run once, the four consumer workflows can pull \`:latest\` and this PR can come out of draft. Same command rebuilds it whenever the Dockerfile, \`docs/requirements.txt\`, or \`pyproject.toml\` change.

## Deliberately not touched

- \`tox.ini\` \`[testenv:docs]\` still pip installs from \`docs/requirements.txt\` for local tox runs. With #257's \`numba>=0.60\` floor that path is healthy; containerizing it is a separate (smaller) question.
- The \`github-actions.yml\` \`docs\` matrix entry runs tox and likewise relies on #257's resolver fix, not this image.
- A GHA \`build-docs-image.yml\` could be added later if hand-rebuilds get annoying — it would just need \`ARTIFACTORY_USERNAME\` / \`ARTIFACTORY_PASSWORD\` repo secrets and the same \`buildx build --push\` invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)