### PR TITLE
Clarify 4 Params classes and accept natural-language field aliases

### DIFF
--- a/src/laser/measles/abm/components/process_infection.py
+++ b/src/laser/measles/abm/components/process_infection.py
@@ -65,7 +65,7 @@ class InfectionParams(BaseInfectionParams):
         ),
         ge=0.0,
         le=1.0,
-        validation_alias=AliasChoices("seasonality", "seasonal_amplitude", "amplitude"),
+        validation_alias=AliasChoices("seasonality", "seasonal_amplitude"),
     )
     season_start: float = Field(default=0, description="Season start day (0-364)", ge=0, le=364)
     exp_mu: float = Field(default=6.0, description="Exposure mean (lognormal)", gt=0.0)

--- a/src/laser/measles/abm/components/process_infection.py
+++ b/src/laser/measles/abm/components/process_infection.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import numpy as np
 from matplotlib.figure import Figure
+from pydantic import AliasChoices
 from pydantic import Field
 
 from laser.measles.abm.model import ABMModel
@@ -55,7 +56,17 @@ class InfectionParams(BaseInfectionParams):
     """
 
     beta: float = Field(default=1.0, description="Base transmission rate", ge=0.0)
-    seasonality: float = Field(default=0.0, description="Seasonality factor", ge=0.0, le=1.0)
+    seasonality: float = Field(
+        default=0.0,
+        description=(
+            "Amplitude of seasonal modulation of beta (range 0.0-1.0; e.g. 0.3 = "
+            "30% amplitude, 0.0 = no seasonality). Accepts either `seasonality` "
+            "or `seasonal_amplitude` on input. Pairs with `season_start`."
+        ),
+        ge=0.0,
+        le=1.0,
+        validation_alias=AliasChoices("seasonality", "seasonal_amplitude"),
+    )
     season_start: float = Field(default=0, description="Season start day (0-364)", ge=0, le=364)
     exp_mu: float = Field(default=6.0, description="Exposure mean (lognormal)", gt=0.0)
     exp_sigma: float = Field(default=2.0, description="Exposure sigma (lognormal)", gt=0.0)

--- a/src/laser/measles/abm/components/process_infection.py
+++ b/src/laser/measles/abm/components/process_infection.py
@@ -65,7 +65,7 @@ class InfectionParams(BaseInfectionParams):
         ),
         ge=0.0,
         le=1.0,
-        validation_alias=AliasChoices("seasonality", "seasonal_amplitude"),
+        validation_alias=AliasChoices("seasonality", "seasonal_amplitude", "amplitude"),
     )
     season_start: float = Field(default=0, description="Season start day (0-364)", ge=0, le=364)
     exp_mu: float = Field(default=6.0, description="Exposure mean (lognormal)", gt=0.0)

--- a/src/laser/measles/abm/components/process_infection_seeding.py
+++ b/src/laser/measles/abm/components/process_infection_seeding.py
@@ -45,9 +45,7 @@ class InfectionSeedingParams(BaseModel):
         validation_alias=AliasChoices("num_infections", "n_seeds", "n_initial_infections"),
     )
     target_patches: list[str] | None = Field(default=None, description="List of specific patch IDs to seed")
-    infections_per_patch: (
-        int | list[int]
-    ) | None = Field(
+    infections_per_patch: (int | list[int]) | None = Field(
         default=None,
         description=(
             "Per-patch override of `num_infections`: an int (same count for every patch "

--- a/src/laser/measles/abm/components/process_infection_seeding.py
+++ b/src/laser/measles/abm/components/process_infection_seeding.py
@@ -6,6 +6,7 @@ selects the largest patch by population for seeding.
 """
 
 import numpy as np
+from pydantic import AliasChoices
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
@@ -31,11 +32,29 @@ class InfectionSeedingParams(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    num_infections: int = Field(default=1, description="Default number of infections to seed", ge=1)
+    num_infections: int = Field(
+        default=1,
+        description=(
+            "Number of infections to seed per patch (used for every patch in "
+            "`target_patches`, and for the largest patch when `target_patches` is None "
+            "and `use_largest_patch=True`). To set different counts per patch, use "
+            "`infections_per_patch` instead. Accepts `num_infections`, `n_seeds`, or "
+            "`n_initial_infections` on input."
+        ),
+        ge=1,
+        validation_alias=AliasChoices("num_infections", "n_seeds", "n_initial_infections"),
+    )
     target_patches: list[str] | None = Field(default=None, description="List of specific patch IDs to seed")
     infections_per_patch: (
         int | list[int]
-    ) | None = Field(default=None, description="Number of infections per patch (single int or list matching target_patches)")
+    ) | None = Field(
+        default=None,
+        description=(
+            "Per-patch override of `num_infections`: an int (same count for every patch "
+            "in `target_patches`) or a list of ints (one per target patch, lengths must "
+            "match). Leave None to use `num_infections` uniformly."
+        ),
+    )
     use_largest_patch: bool = Field(default=True, description="Whether to seed the largest patch by default")
 
     @field_validator("infections_per_patch")

--- a/src/laser/measles/biweekly/components/process_infection.py
+++ b/src/laser/measles/biweekly/components/process_infection.py
@@ -34,7 +34,7 @@ class InfectionParams(BaseInfectionParams):
         ),
         ge=0.0,
         le=1.0,
-        validation_alias=AliasChoices("seasonality", "seasonal_amplitude", "amplitude"),
+        validation_alias=AliasChoices("seasonality", "seasonal_amplitude"),
     )
     season_start: int = Field(default=0, description="Season start tick (0-25)", ge=0, le=25)
     mixer: Any = Field(default_factory=lambda: GravityMixing(), description="Mixing object")

--- a/src/laser/measles/biweekly/components/process_infection.py
+++ b/src/laser/measles/biweekly/components/process_infection.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import numpy as np
+from pydantic import AliasChoices
 from pydantic import Field
 
 from laser.measles.base import BaseLaserModel
@@ -24,7 +25,17 @@ class InfectionParams(BaseInfectionParams):
     beta: float = Field(
         default=1 * 8 / 14, description="Base transmission rate (infections per day)", ge=0.0
     )  # beta = R0 / (mean infectious period)
-    seasonality: float = Field(default=0.0, description="Seasonality factor, default is no seasonality", ge=0.0, le=1.0)
+    seasonality: float = Field(
+        default=0.0,
+        description=(
+            "Amplitude of seasonal modulation of beta (range 0.0-1.0; e.g. 0.3 = "
+            "30% amplitude, 0.0 = no seasonality). Accepts either `seasonality` "
+            "or `seasonal_amplitude` on input. Pairs with `season_start`."
+        ),
+        ge=0.0,
+        le=1.0,
+        validation_alias=AliasChoices("seasonality", "seasonal_amplitude"),
+    )
     season_start: int = Field(default=0, description="Season start tick (0-25)", ge=0, le=25)
     mixer: Any = Field(default_factory=lambda: GravityMixing(), description="Mixing object")
 

--- a/src/laser/measles/biweekly/components/process_infection.py
+++ b/src/laser/measles/biweekly/components/process_infection.py
@@ -34,7 +34,7 @@ class InfectionParams(BaseInfectionParams):
         ),
         ge=0.0,
         le=1.0,
-        validation_alias=AliasChoices("seasonality", "seasonal_amplitude"),
+        validation_alias=AliasChoices("seasonality", "seasonal_amplitude", "amplitude"),
     )
     season_start: int = Field(default=0, description="Season start tick (0-25)", ge=0, le=25)
     mixer: Any = Field(default_factory=lambda: GravityMixing(), description="Mixing object")

--- a/src/laser/measles/compartmental/components/process_infection.py
+++ b/src/laser/measles/compartmental/components/process_infection.py
@@ -5,6 +5,7 @@ Component for simulating the SEIR infection process in the compartmental model.
 from typing import Any
 
 import numpy as np
+from pydantic import AliasChoices
 from pydantic import Field
 
 from laser.measles.base import BaseLaserModel
@@ -41,7 +42,17 @@ class InfectionParams(BaseInfectionParams):
     beta: float = Field(default=1.0, description="Base transmission rate", ge=0.0)
     exp_mu: float = Field(default=6.0, description="Exposure mean", gt=0.0)
     inf_mu: float = Field(default=8.0, description="Infection mean", gt=0.0)
-    seasonality: float = Field(default=0.0, description="Seasonality factor, default is no seasonality", ge=0.0, le=1.0)
+    seasonality: float = Field(
+        default=0.0,
+        description=(
+            "Amplitude of seasonal modulation of beta (range 0.0-1.0; e.g. 0.3 = "
+            "30% amplitude, 0.0 = no seasonality). Accepts either `seasonality` "
+            "or `seasonal_amplitude` on input. Pairs with `season_start`."
+        ),
+        ge=0.0,
+        le=1.0,
+        validation_alias=AliasChoices("seasonality", "seasonal_amplitude"),
+    )
     season_start: float = Field(default=0, description="Season start day (0-364)", ge=0, le=364)
     mixer: Any = Field(default_factory=lambda: GravityMixing(), description="Spatial mixing model")
 

--- a/src/laser/measles/compartmental/components/process_infection.py
+++ b/src/laser/measles/compartmental/components/process_infection.py
@@ -51,7 +51,7 @@ class InfectionParams(BaseInfectionParams):
         ),
         ge=0.0,
         le=1.0,
-        validation_alias=AliasChoices("seasonality", "seasonal_amplitude", "amplitude"),
+        validation_alias=AliasChoices("seasonality", "seasonal_amplitude"),
     )
     season_start: float = Field(default=0, description="Season start day (0-364)", ge=0, le=364)
     mixer: Any = Field(default_factory=lambda: GravityMixing(), description="Spatial mixing model")

--- a/src/laser/measles/compartmental/components/process_infection.py
+++ b/src/laser/measles/compartmental/components/process_infection.py
@@ -51,7 +51,7 @@ class InfectionParams(BaseInfectionParams):
         ),
         ge=0.0,
         le=1.0,
-        validation_alias=AliasChoices("seasonality", "seasonal_amplitude"),
+        validation_alias=AliasChoices("seasonality", "seasonal_amplitude", "amplitude"),
     )
     season_start: float = Field(default=0, description="Season start day (0-364)", ge=0, le=364)
     mixer: Any = Field(default_factory=lambda: GravityMixing(), description="Spatial mixing model")

--- a/src/laser/measles/components/base_case_surveillance.py
+++ b/src/laser/measles/components/base_case_surveillance.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import polars as pl
 from matplotlib.figure import Figure
+from pydantic import AliasChoices
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
@@ -39,7 +40,26 @@ class BaseCaseSurveillanceParams(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    detection_rate: float = Field(default=0.1, description="Probability of detecting an infected case", ge=0.0, le=1.0)
+    detection_rate: float = Field(
+        default=0.1,
+        description=(
+            "Per-case probability of detection / notification under passive surveillance "
+            "(0.0-1.0; e.g. 0.3 = 30% of true infections are detected and reported). "
+            "Accepts `detection_rate`, `detection_probability`, `reporting_prob`, "
+            "`reporting_probability`, `notification_rate`, or `notification_probability` "
+            "on input."
+        ),
+        ge=0.0,
+        le=1.0,
+        validation_alias=AliasChoices(
+            "detection_rate",
+            "detection_probability",
+            "reporting_prob",
+            "reporting_probability",
+            "notification_rate",
+            "notification_probability",
+        ),
+    )
     filter_fn: Callable[[str], bool] = Field(default=lambda x: True, description="Function to filter which nodes to include in aggregation")
     aggregation_level: int = Field(default=-1, description="Number of levels to use for aggregation (e.g., 2 for country:state:lga)")
 

--- a/src/laser/measles/components/base_infection.py
+++ b/src/laser/measles/components/base_infection.py
@@ -34,7 +34,7 @@ class BaseInfectionParams(BaseModel):
         ),
         ge=0.0,
         le=1.0,
-        validation_alias=AliasChoices("seasonality", "seasonal_amplitude", "amplitude"),
+        validation_alias=AliasChoices("seasonality", "seasonal_amplitude"),
     )
     season_start: int = Field(default=0, description="Season start tick (0-25)", ge=0, le=25)
     distance_exponent: float = Field(default=1.5, description="Distance exponent", ge=0.0)

--- a/src/laser/measles/components/base_infection.py
+++ b/src/laser/measles/components/base_infection.py
@@ -34,7 +34,7 @@ class BaseInfectionParams(BaseModel):
         ),
         ge=0.0,
         le=1.0,
-        validation_alias=AliasChoices("seasonality", "seasonal_amplitude"),
+        validation_alias=AliasChoices("seasonality", "seasonal_amplitude", "amplitude"),
     )
     season_start: int = Field(default=0, description="Season start tick (0-25)", ge=0, le=25)
     distance_exponent: float = Field(default=1.5, description="Distance exponent", ge=0.0)

--- a/src/laser/measles/components/base_infection.py
+++ b/src/laser/measles/components/base_infection.py
@@ -1,5 +1,6 @@
 from abc import ABC
 
+from pydantic import AliasChoices
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
@@ -24,7 +25,17 @@ class BaseInfectionParams(BaseModel):
     beta: float = Field(
         default=1, description="Base transmission rate (infections per day)", ge=0.0
     )  # beta = R0 / (mean infectious period)
-    seasonality: float = Field(default=0.0, description="Seasonality factor, default is no seasonality", ge=0.0, le=1.0)
+    seasonality: float = Field(
+        default=0.0,
+        description=(
+            "Amplitude of seasonal modulation of beta (range 0.0-1.0; e.g. 0.3 = "
+            "30% amplitude, 0.0 = no seasonality). Accepts either `seasonality` "
+            "or `seasonal_amplitude` on input. Pairs with `season_start`."
+        ),
+        ge=0.0,
+        le=1.0,
+        validation_alias=AliasChoices("seasonality", "seasonal_amplitude"),
+    )
     season_start: int = Field(default=0, description="Season start tick (0-25)", ge=0, le=25)
     distance_exponent: float = Field(default=1.5, description="Distance exponent", ge=0.0)
     mixing_scale: float = Field(default=0.001, description="Mixing scale", ge=0.0)

--- a/src/laser/measles/components/base_infection_seeding.py
+++ b/src/laser/measles/components/base_infection_seeding.py
@@ -43,9 +43,7 @@ class BaseInfectionSeedingParams(BaseModel):
         validation_alias=AliasChoices("num_infections", "n_seeds", "n_initial_infections"),
     )
     target_patches: list[str] | None = Field(default=None, description="List of specific patch IDs to seed")
-    infections_per_patch: (
-        int | list[int]
-    ) | None = Field(
+    infections_per_patch: (int | list[int]) | None = Field(
         default=None,
         description=(
             "Per-patch override of `num_infections`: an int (same count for every patch "

--- a/src/laser/measles/components/base_infection_seeding.py
+++ b/src/laser/measles/components/base_infection_seeding.py
@@ -5,6 +5,7 @@ Component for seeding initial infections in the compartmental model.
 from abc import abstractmethod
 
 import numpy as np
+from pydantic import AliasChoices
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
@@ -29,11 +30,29 @@ class BaseInfectionSeedingParams(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    num_infections: int = Field(default=1, description="Default number of infections to seed", ge=1)
+    num_infections: int = Field(
+        default=1,
+        description=(
+            "Number of infections to seed per patch (used for every patch in "
+            "`target_patches`, and for the largest patch when `target_patches` is None "
+            "and `use_largest_patch=True`). To set different counts per patch, use "
+            "`infections_per_patch` instead. Accepts `num_infections`, `n_seeds`, or "
+            "`n_initial_infections` on input."
+        ),
+        ge=1,
+        validation_alias=AliasChoices("num_infections", "n_seeds", "n_initial_infections"),
+    )
     target_patches: list[str] | None = Field(default=None, description="List of specific patch IDs to seed")
     infections_per_patch: (
         int | list[int]
-    ) | None = Field(default=None, description="Number of infections per patch (single int or list matching target_patches)")
+    ) | None = Field(
+        default=None,
+        description=(
+            "Per-patch override of `num_infections`: an int (same count for every patch "
+            "in `target_patches`) or a list of ints (one per target patch, lengths must "
+            "match). Leave None to use `num_infections` uniformly."
+        ),
+    )
     use_largest_patch: bool = Field(default=True, description="Whether to seed the largest patch by default")
 
     @field_validator("infections_per_patch")

--- a/src/laser/measles/components/base_initialize_equilibrium_states.py
+++ b/src/laser/measles/components/base_initialize_equilibrium_states.py
@@ -3,6 +3,7 @@ Component for initializing the population in each of the model states by rough e
 """
 
 import numpy as np
+from pydantic import AliasChoices
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
@@ -27,7 +28,17 @@ class BaseInitializeEquilibriumStatesParams(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    R0: float = Field(default=8.0, description="Basic reproduction number setting the initialization", ge=0.0)
+    R0: float = Field(
+        default=8.0,
+        description=(
+            "Basic reproduction number used to set initial S and R partition "
+            "(S = N/R0, R = N*(1 - 1/R0)). For R0 <= 1 no endemic equilibrium "
+            "exists and the whole population is placed in S. Accepts `R0`, "
+            "`effective_R0`, `effective_r0`, or `R_0` on input."
+        ),
+        ge=0.0,
+        validation_alias=AliasChoices("R0", "effective_R0", "effective_r0", "R_0"),
+    )
 
 
 class BaseInitializeEquilibriumStatesProcess(BasePhase):

--- a/src/laser/measles/components/base_initialize_equilibrium_states.py
+++ b/src/laser/measles/components/base_initialize_equilibrium_states.py
@@ -33,11 +33,11 @@ class BaseInitializeEquilibriumStatesParams(BaseModel):
         description=(
             "Basic reproduction number used to set initial S and R partition "
             "(S = N/R0, R = N*(1 - 1/R0)). For R0 <= 1 no endemic equilibrium "
-            "exists and the whole population is placed in S. Accepts `R0`, "
-            "`effective_R0`, `effective_r0`, or `R_0` on input."
+            "exists and the whole population is placed in S. Accepts `R0`, `r0`, "
+            "`R_0`, `effective_R0`, or `effective_r0` on input."
         ),
         ge=0.0,
-        validation_alias=AliasChoices("R0", "effective_R0", "effective_r0", "R_0"),
+        validation_alias=AliasChoices("R0", "r0", "R_0", "effective_R0", "effective_r0"),
     )
 
 

--- a/src/laser/measles/components/results_writer.py
+++ b/src/laser/measles/components/results_writer.py
@@ -11,6 +11,7 @@ import json
 from pathlib import Path
 
 import numpy as np
+from pydantic import AliasChoices
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
@@ -31,7 +32,13 @@ class ResultsWriterParams(BaseModel):
 
     path: str = Field(
         default="results.json",
-        description="Destination file for the JSON results dump.",
+        description=(
+            "Destination *file path* for the JSON results dump (e.g. "
+            "`'results.json'` or `'output/run42.json'`). This is the full "
+            "file path, not a directory — to write into a directory, include "
+            "the filename. Accepts `path`, `output_file`, or `output_path` on input."
+        ),
+        validation_alias=AliasChoices("path", "output_file", "output_path"),
     )
 
 

--- a/tests/unit/test_params_no_silent_ignore.py
+++ b/tests/unit/test_params_no_silent_ignore.py
@@ -81,3 +81,91 @@ def test_vital_dynamics_cbr_typo_does_not_silently_default():
     """Concrete documentation of the user-memory bug: cbr=50 → was using 20.0."""
     with pytest.raises(ValidationError, match=r"cbr"):
         VitalDynamicsParams(cbr=50, cdr=30)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Alias contract: validation_alias accepts the documented synonym(s),
+# model_dump() always emits the canonical field name. The dual property —
+# input-permissive, output-canonical — is the whole point of using
+# validation_alias rather than plain alias. Lock both directions in.
+# ──────────────────────────────────────────────────────────────────────
+
+from laser.measles.abm.components.process_infection import InfectionParams as ABMInfectionParams
+from laser.measles.abm.components.process_infection_seeding import InfectionSeedingParams as ABMSeedingParams
+from laser.measles.biweekly.components.process_infection import InfectionParams as BWInfectionParams
+from laser.measles.biweekly.components.process_infection_seeding import InfectionSeedingParams as BWSeedingParams
+from laser.measles.biweekly.components.process_initialize_equilibrium_states import (
+    InitializeEquilibriumStatesParams as BWInitEq,
+)
+from laser.measles.biweekly.components.tracker_case_surveillance import CaseSurveillanceParams as BWCaseSurveillance
+from laser.measles.compartmental.components.process_infection import InfectionParams as CompInfectionParams
+from laser.measles.components import ResultsWriterParams
+
+
+@pytest.mark.parametrize(
+    ("params_cls", "canonical_field", "alias_kwarg", "value"),
+    [
+        # InfectionParams.seasonality — the field is declared at the base AND
+        # redeclared at each of the three subclasses. Pydantic field overrides
+        # discard parent alias config, so the alias has to live on each
+        # subclass declaration too — exercise all three to lock that in.
+        pytest.param(ABMInfectionParams, "seasonality", "seasonal_amplitude", 0.3, id="abm-infection-seasonal_amplitude"),
+        pytest.param(BWInfectionParams, "seasonality", "seasonal_amplitude", 0.3, id="biweekly-infection-seasonal_amplitude"),
+        pytest.param(CompInfectionParams, "seasonality", "seasonal_amplitude", 0.3, id="compartmental-infection-seasonal_amplitude"),
+        # ResultsWriterParams.path
+        pytest.param(ResultsWriterParams, "path", "output_file", "/tmp/x.json", id="results_writer-output_file"),
+        pytest.param(ResultsWriterParams, "path", "output_path", "/tmp/x.json", id="results_writer-output_path"),
+        # InfectionSeedingParams.num_infections — biweekly+compartmental share
+        # BaseInfectionSeedingParams via empty subclass pass-through. ABM has its
+        # own parallel BaseModel declaration that has to carry the alias too.
+        pytest.param(BWSeedingParams, "num_infections", "n_seeds", 5, id="biweekly-seeding-n_seeds"),
+        pytest.param(BWSeedingParams, "num_infections", "n_initial_infections", 5, id="biweekly-seeding-n_initial_infections"),
+        pytest.param(ABMSeedingParams, "num_infections", "n_seeds", 5, id="abm-seeding-n_seeds"),
+        pytest.param(ABMSeedingParams, "num_infections", "n_initial_infections", 5, id="abm-seeding-n_initial_infections"),
+        # InitializeEquilibriumStatesParams.R0 — all three variants share the base.
+        pytest.param(BWInitEq, "R0", "r0", 4.0, id="initeq-r0"),
+        pytest.param(BWInitEq, "R0", "R_0", 4.0, id="initeq-R_0"),
+        pytest.param(BWInitEq, "R0", "effective_R0", 4.0, id="initeq-effective_R0"),
+        pytest.param(BWInitEq, "R0", "effective_r0", 4.0, id="initeq-effective_r0"),
+        # CaseSurveillanceParams.detection_rate — all three variants share the base.
+        pytest.param(BWCaseSurveillance, "detection_rate", "reporting_prob", 0.3, id="surveillance-reporting_prob"),
+        pytest.param(BWCaseSurveillance, "detection_rate", "reporting_probability", 0.3, id="surveillance-reporting_probability"),
+        pytest.param(BWCaseSurveillance, "detection_rate", "notification_rate", 0.3, id="surveillance-notification_rate"),
+        pytest.param(BWCaseSurveillance, "detection_rate", "notification_probability", 0.3, id="surveillance-notification_probability"),
+        pytest.param(BWCaseSurveillance, "detection_rate", "detection_probability", 0.3, id="surveillance-detection_probability"),
+    ],
+)
+def test_params_accept_documented_alias(params_cls, canonical_field, alias_kwarg, value):
+    """Alias kwarg constructs cleanly AND model_dump() emits the canonical key.
+
+    validation_alias is input-only, so consumers serializing the params back
+    out (logging, JSON round-trip, results.json, etc.) always see the
+    canonical field name regardless of which alias the user supplied.
+    """
+    p = params_cls(**{alias_kwarg: value})
+
+    # Alias populated the canonical field
+    assert getattr(p, canonical_field) == value
+
+    # Canonical key is on output
+    dump = p.model_dump()
+    assert canonical_field in dump
+    assert dump[canonical_field] == value
+
+    # Alias key is NOT on output (would indicate plain alias was used instead
+    # of validation_alias — that would surprise downstream consumers)
+    assert alias_kwarg == canonical_field or alias_kwarg not in dump
+
+
+@pytest.mark.parametrize(
+    "params_cls",
+    [ABMInfectionParams, BWInfectionParams, CompInfectionParams],
+    ids=["abm", "biweekly", "compartmental"],
+)
+def test_seasonality_rejects_bare_amplitude(params_cls):
+    """`amplitude` (bare, no prefix) is intentionally NOT an alias for
+    `seasonality`. Too generic, undocumented in the field description.
+    Keep it rejected loudly so a future drive-by addition has to defend it.
+    """
+    with pytest.raises(ValidationError):
+        params_cls(amplitude=0.3)

--- a/tests/unit/test_params_no_silent_ignore.py
+++ b/tests/unit/test_params_no_silent_ignore.py
@@ -25,7 +25,15 @@ from pydantic import ValidationError
 from laser.measles.abm.components import InfectionParams
 from laser.measles.abm.components import InfectionSeedingParams
 from laser.measles.abm.components import VitalDynamicsParams
+from laser.measles.abm.components.process_infection import InfectionParams as ABMInfectionParams
+from laser.measles.abm.components.process_infection_seeding import InfectionSeedingParams as ABMSeedingParams
 from laser.measles.abm.components.process_transmission import TransmissionParams
+from laser.measles.biweekly.components.process_infection import InfectionParams as BWInfectionParams
+from laser.measles.biweekly.components.process_infection_seeding import InfectionSeedingParams as BWSeedingParams
+from laser.measles.biweekly.components.process_initialize_equilibrium_states import InitializeEquilibriumStatesParams as BWInitEq
+from laser.measles.biweekly.components.tracker_case_surveillance import CaseSurveillanceParams as BWCaseSurveillance
+from laser.measles.compartmental.components.process_infection import InfectionParams as CompInfectionParams
+from laser.measles.components import ResultsWriterParams
 
 
 @pytest.mark.parametrize(
@@ -90,17 +98,6 @@ def test_vital_dynamics_cbr_typo_does_not_silently_default():
 # validation_alias rather than plain alias. Lock both directions in.
 # ──────────────────────────────────────────────────────────────────────
 
-from laser.measles.abm.components.process_infection import InfectionParams as ABMInfectionParams
-from laser.measles.abm.components.process_infection_seeding import InfectionSeedingParams as ABMSeedingParams
-from laser.measles.biweekly.components.process_infection import InfectionParams as BWInfectionParams
-from laser.measles.biweekly.components.process_infection_seeding import InfectionSeedingParams as BWSeedingParams
-from laser.measles.biweekly.components.process_initialize_equilibrium_states import (
-    InitializeEquilibriumStatesParams as BWInitEq,
-)
-from laser.measles.biweekly.components.tracker_case_surveillance import CaseSurveillanceParams as BWCaseSurveillance
-from laser.measles.compartmental.components.process_infection import InfectionParams as CompInfectionParams
-from laser.measles.components import ResultsWriterParams
-
 
 @pytest.mark.parametrize(
     ("params_cls", "canonical_field", "alias_kwarg", "value"),
@@ -113,8 +110,8 @@ from laser.measles.components import ResultsWriterParams
         pytest.param(BWInfectionParams, "seasonality", "seasonal_amplitude", 0.3, id="biweekly-infection-seasonal_amplitude"),
         pytest.param(CompInfectionParams, "seasonality", "seasonal_amplitude", 0.3, id="compartmental-infection-seasonal_amplitude"),
         # ResultsWriterParams.path
-        pytest.param(ResultsWriterParams, "path", "output_file", "/tmp/x.json", id="results_writer-output_file"),
-        pytest.param(ResultsWriterParams, "path", "output_path", "/tmp/x.json", id="results_writer-output_path"),
+        pytest.param(ResultsWriterParams, "path", "output_file", "results.json", id="results_writer-output_file"),
+        pytest.param(ResultsWriterParams, "path", "output_path", "results.json", id="results_writer-output_path"),
         # InfectionSeedingParams.num_infections — biweekly+compartmental share
         # BaseInfectionSeedingParams via empty subclass pass-through. ABM has its
         # own parallel BaseModel declaration that has to carry the alias too.


### PR DESCRIPTION
## Motivation

The jenner-measles-mcp 20-prompt alpha test surfaces a recurring failure: **5 of 20 prompts** hit a first-attempt \`pydantic_core.ValidationError\` on Params constructors — all of them \`extra_forbidden\`. The model is reaching for natural-language field names that fit the user prompt's wording, and \`model_config = ConfigDict(extra=\"forbid\")\` is rejecting them. The model is *correct* about the intent; the API just has a less-obvious canonical name.

This PR applies the same fix at the source for all six (one extra surfaced when the live test was re-run with the corpus active): sharper description + \`validation_alias=AliasChoices(...)\` so the natural-language guess constructs cleanly. \`validation_alias\` (input-only) preserves canonical names on \`model_dump()\` / serialization — downstream consumers expecting the original keys are unaffected.

## Fields touched

| Class | File | Canonical | Now also accepts | Description sharpened |
|---|---|---|---|---|
| \`InfectionParams\` | \`components/base_infection.py\` + 3 subclass redeclarations in abm/biweekly/compartmental | \`seasonality\` | \`seasonal_amplitude\` | Range and \"0.3 = 30% amplitude\" spelled out, pairing with \`season_start\` noted. Bare \`amplitude\` deliberately **not** an alias — too generic and undocumented (locked in by `test_seasonality_rejects_bare_amplitude`) |
| \`ResultsWriterParams\` | \`components/results_writer.py\` | \`path\` | \`output_file\`, \`output_path\` | Says explicitly \"file path, not directory\" with examples. Deliberately does **not** alias \`output_dir\` — would silently route a directory string into a file path and break at runtime |
| \`InfectionSeedingParams\` (Base) | \`components/base_infection_seeding.py\` | \`num_infections\` | \`n_seeds\`, \`n_initial_infections\` | Calls out per-patch semantics under \`target_patches\`; \`infections_per_patch\` description now framed as \"per-patch override of num_infections\" |
| \`InfectionSeedingParams\` (ABM) | \`abm/components/process_infection_seeding.py\` | \`num_infections\` | \`n_seeds\`, \`n_initial_infections\` | Same — the ABM variant is a standalone \`BaseModel\` (not a subclass of the base), so the aliases have to live there too |
| \`InitializeEquilibriumStatesParams\` | \`components/base_initialize_equilibrium_states.py\` | \`R0\` | \`r0\`, \`R_0\`, \`effective_R0\`, \`effective_r0\` | Spells out the math (\`S = N/R0\`, \`R = N(1 - 1/R0)\`) and the \`R0 ≤ 1\` fallback |
| \`CaseSurveillanceParams\` | \`components/base_case_surveillance.py\` | \`detection_rate\` | \`detection_probability\`, \`reporting_prob\`, \`reporting_probability\`, \`notification_rate\`, \`notification_probability\` | Spells out the per-case semantics (passive surveillance, true→reported fraction) with the \"0.3 = 30%\" example |

\`extra=\"forbid\"\` is preserved everywhere — typo'd field names still error loudly; only specific intended synonyms are allowed.

## Tests

20 new parametrized cases in \`tests/unit/test_params_no_silent_ignore.py\` (the existing home for pydantic Params validation invariants — already had the \"extra='forbid' rejects unknown kwargs\" coverage; this adds the complementary \"documented alias accepted, canonical key on output\" side):

- 17 \`test_params_accept_documented_alias[...]\` cases — every (class, alias) pair listed in the table above. Each asserts construction sets the canonical field AND \`model_dump()\` emits the canonical key (validation_alias input-only invariant).
- 3 \`test_seasonality_rejects_bare_amplitude[abm|biweekly|compartmental]\` cases — locks in the scope-tightening of dropping bare \`amplitude\` (too generic, undocumented).

All passing locally.

## Expected impact

Together with the seasonality fix, the five (now six) first-attempt pydantic-validation failures across the alpha 20-prompt suite are addressed at the source. End-to-end re-run after corpus rebuild + ingest holds at 19/20 — alpha-baseline parity. First-try pass count oscillates 9-14 across runs (sampling variance on a 20-prompt suite); the alias mechanism is a runtime safety net for whatever the model reaches for after the new descriptions land in the corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)