### PR TITLE
Add LASER_GADM_MIRROR override; wire IDM Artifactory mirror in CI

### DIFF
--- a/.github/workflows/build-jenner-doc.yml
+++ b/.github/workflows/build-jenner-doc.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # Redirect GADM downloads (used by tutorial-execution step) to the IDM
+      # Artifactory mirror so doc builds don't break when geodata.ucdavis.edu
+      # is unreachable.
+      LASER_GADM_MIRROR: https://packages.idmod.org/artifactory/idm-data
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/mkdocs-ghp.yml
+++ b/.github/workflows/mkdocs-ghp.yml
@@ -9,6 +9,11 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      # Redirect GADM downloads (used by tutorial-execution during mkdocs build)
+      # to the IDM Artifactory mirror so gh-pages deploys don't break when
+      # geodata.ucdavis.edu is unreachable.
+      LASER_GADM_MIRROR: https://packages.idmod.org/artifactory/idm-data
     steps:
       - uses: actions/checkout@v4
       - name: Configure Git Credentials

--- a/.github/workflows/mkdocs-pr.yml
+++ b/.github/workflows/mkdocs-pr.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # Redirect GADM downloads (used by tutorial-execution step) to the IDM
+      # Artifactory mirror so PR builds don't break when geodata.ucdavis.edu
+      # is unreachable.
+      LASER_GADM_MIRROR: https://packages.idmod.org/artifactory/idm-data
 
     steps:
       - name: Checkout code

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -32,6 +32,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      # Redirect GADM downloads (used by tutorial-execution during mkdocs build)
+      # to the IDM Artifactory mirror so releases don't break when
+      # geodata.ucdavis.edu is unreachable.
+      LASER_GADM_MIRROR: https://packages.idmod.org/artifactory/idm-data
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Configure Git Credentials
@@ -128,6 +133,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      # Redirect GADM downloads (used by tutorial-execution during the combined-doc
+      # build) to the IDM Artifactory mirror so releases don't break when
+      # geodata.ucdavis.edu is unreachable.
+      LASER_GADM_MIRROR: https://packages.idmod.org/artifactory/idm-data
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/docs/user-guide/model-types/demographics.md
+++ b/docs/user-guide/model-types/demographics.md
@@ -67,6 +67,15 @@ gadm = GADMShapefile(shapefile="./data/gadm41_ETH_2.shp")
 df = gadm.get_dataframe()
 ```
 
+**Mirror override.** `GADMShapefile.download` fetches from `geodata.ucdavis.edu` by default. If UCDavis is unreachable from your network (corporate firewall, transient outage), set the `LASER_GADM_MIRROR` environment variable to point at an alternate host that mirrors GADM's path layout. The Institute for Disease Modeling maintains a mirror at `https://packages.idmod.org/artifactory/idm-data` (read-only, no auth required); the laser-measles CI workflows use it by default. To opt in locally:
+
+```bash
+export LASER_GADM_MIRROR=https://packages.idmod.org/artifactory/idm-data
+python -c "from laser.measles.demographics import GADMShapefile; GADMShapefile.download('ETH', admin_level=1, directory='./data')"
+```
+
+The override replaces only the host; the path layout (`/gadm/gadm<VERSION>/shp/gadm<VERSION_INT>_<COUNTRY_CODE>_shp.zip`) must match upstream.
+
 ### RasterPatchGenerator
 
 Generates patch-level demographic data by clipping rasters to administrative boundaries.

--- a/docs/user-guide/model-types/demographics.md
+++ b/docs/user-guide/model-types/demographics.md
@@ -67,14 +67,14 @@ gadm = GADMShapefile(shapefile="./data/gadm41_ETH_2.shp")
 df = gadm.get_dataframe()
 ```
 
-**Mirror override.** `GADMShapefile.download` fetches from `geodata.ucdavis.edu` by default. If UCDavis is unreachable from your network (corporate firewall, transient outage), set the `LASER_GADM_MIRROR` environment variable to point at an alternate host that mirrors GADM's path layout. The Institute for Disease Modeling maintains a mirror at `https://packages.idmod.org/artifactory/idm-data` (read-only, no auth required); the laser-measles CI workflows use it by default. To opt in locally:
+**Mirror override.** `GADMShapefile.download` fetches from `https://geodata.ucdavis.edu` by default. If UCDavis is unreachable from your network (corporate firewall, transient outage), set the `LASER_GADM_MIRROR` environment variable to an alternate base URL that mirrors GADM's path layout. The Institute for Disease Modeling maintains a mirror at `https://packages.idmod.org/artifactory/idm-data` (read-only, no auth required); the laser-measles CI workflows use it by default. To opt in locally:
 
 ```bash
 export LASER_GADM_MIRROR=https://packages.idmod.org/artifactory/idm-data
 python -c "from laser.measles.demographics import GADMShapefile; GADMShapefile.download('ETH', admin_level=1, directory='./data')"
 ```
 
-The override replaces only the host; the path layout (`/gadm/gadm<VERSION>/shp/gadm<VERSION_INT>_<COUNTRY_CODE>_shp.zip`) must match upstream.
+The override replaces the base URL (host **and** any path prefix); the remaining path (`/gadm/gadm<VERSION>/shp/gadm<VERSION_INT>_<COUNTRY_CODE>_shp.zip`) is appended automatically and must match upstream. Empty-string and unset values both fall back to the UCDavis default.
 
 ### RasterPatchGenerator
 

--- a/src/laser/measles/demographics/gadm.py
+++ b/src/laser/measles/demographics/gadm.py
@@ -17,14 +17,17 @@ from laser.measles.demographics.admin_shapefile import AdminShapefile
 
 VERSION = "4.1"
 VERSION_INT = VERSION.replace(".", "")
-# Base host for GADM zip downloads. Defaults to GADM's upstream geodata.ucdavis.edu.
-# Override via the LASER_GADM_MIRROR environment variable to point at a different host
-# (e.g. an internal Artifactory mirror) — useful when UCDavis is unreachable from your
-# network (corporate firewall, transient outages). The override only replaces the host;
-# the path layout (/gadm/gadm<VERSION>/shp/gadm<VERSION_INT>_<COUNTRY_CODE>_shp.zip)
-# must match upstream.
-GADM_HOST = os.environ.get("LASER_GADM_MIRROR", "https://geodata.ucdavis.edu").rstrip("/")
-GADM_URL = GADM_HOST + "/gadm/gadm{VERSION}/shp/gadm{VERSION_INT}_{COUNTRY_CODE}_shp.zip"
+# Base URL prefix for GADM zip downloads. Defaults to GADM's upstream
+# https://geodata.ucdavis.edu. Override via the LASER_GADM_MIRROR environment
+# variable to point at a different base URL (e.g. an Artifactory mirror that
+# embeds a repo path) — useful when UCDavis is unreachable from your network
+# (corporate firewall, transient outages). The override may include both host
+# and path prefix (e.g. https://packages.idmod.org/artifactory/idm-data); the
+# remaining path /gadm/gadm<VERSION>/shp/gadm<VERSION_INT>_<COUNTRY_CODE>_shp.zip
+# is appended and must match upstream. Empty-string and unset values both fall
+# back to the upstream default.
+GADM_BASE_URL = (os.environ.get("LASER_GADM_MIRROR") or "https://geodata.ucdavis.edu").rstrip("/")
+GADM_URL = GADM_BASE_URL + "/gadm/gadm{VERSION}/shp/gadm{VERSION_INT}_{COUNTRY_CODE}_shp.zip"
 GADM_SHP_FILE = "gadm{VERSION_INT}_{COUNTRY_CODE}_{LEVEL}.shp"
 DOTNAME_FIELDS_DICT = {
     0: ["COUNTRY"],

--- a/src/laser/measles/demographics/gadm.py
+++ b/src/laser/measles/demographics/gadm.py
@@ -3,6 +3,7 @@ GADM shapefiles
 """
 
 import io
+import os
 import zipfile
 from pathlib import Path
 
@@ -16,7 +17,14 @@ from laser.measles.demographics.admin_shapefile import AdminShapefile
 
 VERSION = "4.1"
 VERSION_INT = VERSION.replace(".", "")
-GADM_URL = "https://geodata.ucdavis.edu/gadm/gadm{VERSION}/shp/gadm{VERSION_INT}_{COUNTRY_CODE}_shp.zip"
+# Base host for GADM zip downloads. Defaults to GADM's upstream geodata.ucdavis.edu.
+# Override via the LASER_GADM_MIRROR environment variable to point at a different host
+# (e.g. an internal Artifactory mirror) — useful when UCDavis is unreachable from your
+# network (corporate firewall, transient outages). The override only replaces the host;
+# the path layout (/gadm/gadm<VERSION>/shp/gadm<VERSION_INT>_<COUNTRY_CODE>_shp.zip)
+# must match upstream.
+GADM_HOST = os.environ.get("LASER_GADM_MIRROR", "https://geodata.ucdavis.edu").rstrip("/")
+GADM_URL = GADM_HOST + "/gadm/gadm{VERSION}/shp/gadm{VERSION_INT}_{COUNTRY_CODE}_shp.zip"
 GADM_SHP_FILE = "gadm{VERSION_INT}_{COUNTRY_CODE}_{LEVEL}.shp"
 DOTNAME_FIELDS_DICT = {
     0: ["COUNTRY"],


### PR DESCRIPTION
## Summary

`geodata.ucdavis.edu` (the upstream GADM shapefile host) has been unreachable from GHA runners for multiple days running, blocking PR #264 and PR #265's `mkdocs-pr.yml` build at the tutorial-execute step (the spatial-scenarios tutorial calls `GADMShapefile.download("ETH")`). Same flake pattern is likely to recur on any future doc-build.

This PR makes the GADM base host configurable via a `LASER_GADM_MIRROR` env var and wires the IDM Artifactory mirror into the four notebook-executing workflows so CI stops being a hostage to UCDavis uptime.

## Changes

- **`src/laser/measles/demographics/gadm.py`** — `GADM_URL` now reads its base host from `LASER_GADM_MIRROR` and defaults to `https://geodata.ucdavis.edu` (preserving existing behavior). Path layout suffix is unchanged.
- **4 workflows** — `build-jenner-doc.yml`, `mkdocs-pr.yml`, `mkdocs-ghp.yml`, `publish-pypi.yml` (both `docs-deploy` and `docs-jenner` jobs) — set `LASER_GADM_MIRROR=https://packages.idmod.org/artifactory/idm-data` at job level.
- **`docs/user-guide/model-types/demographics.md`** — short paragraph documenting the override for users on networks that can't reach UCDavis.

## Mirror state

The IDM Artifactory mirror at `packages.idmod.org/artifactory/idm-data/gadm/gadm4.1/shp/` hosts the three GADM shapefile zips currently referenced by laser-measles' tutorials and docstring examples:

| File | Size | Reachable anonymously? |
|---|---|---|
| `gadm41_ETH_shp.zip` | 1.3 MB | yes (HTTP 200) |
| `gadm41_LUX_shp.zip` | 364 KB | yes (HTTP 200) |
| `gadm41_NGA_shp.zip` | 3.5 MB | yes (HTTP 200) |

## Test plan

- [x] Local sanity: `LASER_GADM_MIRROR=https://packages.idmod.org/artifactory/idm-data python -c "from laser.measles.demographics import gadm; print(gadm.GADM_URL)"` prints the mirror URL.
- [x] Without env var: same import prints the UCDavis URL.
- [ ] CI on this PR completes mkdocs-pr.yml successfully (this PR's CI is the load-bearing test — if `mkdocs-pr.yml` passes, the override + mirror are working in the live environment).

## Follow-up (not blocking)

- `tests/unit/test_gadm.py` downloads CUB (Cuba), which is not yet in the mirror. Seed once UCDavis is reachable again. Until then, fresh dev environments running that test will still hit UCDavis for that one country.

🤖 Generated with [Claude Code](https://claude.com/claude-code)