### PR TITLE
Fix outdated ABM mixer claim in quickstart tutorial

### DIFF
--- a/docs/tutorials/tut_quickstart_hello_world.py
+++ b/docs/tutorials/tut_quickstart_hello_world.py
@@ -84,9 +84,14 @@ model = ABMModel(scenario=scenario, params=params)
 #
 # The key new concept in a spatial model is **how infection crosses patch boundaries**.
 #
-# > **ABM vs compartmental**: The compartmental model accepts an explicit `mixer=` object
-# > (for example, `InfectionParams(mixer=GravityMixing(...))`). The ABM does **not**—it builds
-# > a gravity mixing matrix internally from two parameters:
+# > **Unified mixing API**: Both the ABM and the compartmental model accept an explicit
+# > `mixer=` object on `InfectionParams` — for example, `InfectionParams(mixer=GravityMixing(...))`
+# > or `InfectionParams(mixer=RadiationMixing(...))`. The model assigns the patch scenario to
+# > the mixer automatically at initialization, so callers don't set `mixer.scenario` themselves.
+#
+# **ABM default-gravity convenience.** If you leave `mixer=None` on the ABM's `InfectionParams`,
+# the ABM builds a default `GravityMixing` internally from two parameters on `InfectionParams`.
+# This example takes that convenience path:
 #
 # `distance_exponent`
 # : Controls how quickly mixing declines with distance. A high value (for example, 20) means
@@ -96,9 +101,13 @@ model = ABMModel(scenario=scenario, params=params)
 # `mixing_scale`
 # : Controls the overall strength of cross-patch infection pressure.
 #
-# Each day the ABM (1) counts infectious agents per patch, (2) builds the gravity mixing matrix,
-# (3) computes force of infection per patch, then (4) applies infection probability to each
-# susceptible agent. Agents themselves do not move between patches.
+# When `mixer=` is set explicitly, `distance_exponent` and `mixing_scale` are ignored — the
+# explicit mixer takes precedence. For radiation mixing or any custom mixer, the explicit
+# `mixer=` path is the recommended one.
+#
+# Each day the ABM (1) counts infectious agents per patch, (2) applies the mixing matrix to
+# get force of infection per patch, then (3) applies infection probability to each susceptible
+# agent. Agents themselves do not move between patches.
 
 # %%
 from laser.measles.abm import InfectionParams, InfectionSeedingParams, NoBirthsProcess, InfectionSeedingProcess, InfectionProcess, StateTracker, StateTrackerParams


### PR DESCRIPTION
## Summary

Closes #267.

`docs/tutorials/tut_quickstart_hello_world.py` (`## 4. Spatial mixing` section) had an outdated claim that the ABM "does **not**" accept an explicit `mixer=` object. PR #247 (May 2026, commit `a553662`) added that support, with explicit unit-test coverage in `tests/unit/test_infection_params_mixer.py` (4 tests, all passing).

This PR rewrites the callout to reflect the unified `InfectionParams(mixer=...)` API that both model types now share, while preserving the existing description of `distance_exponent` and `mixing_scale` (still accurate when `mixer=None`).

## Discovery context

Surfaced during Copilot review of PR #265 (`docs/notebook-plot-descriptions`). The plot description for `tut_spatial_mixing.py` inherited the same outdated wording from this tutorial; that occurrence is fixed in #265. This PR closes the loop by fixing the source.

## Test plan

- [x] All four `tests/unit/test_infection_params_mixer.py` tests still pass (rewording only, no code change).
- [ ] CI on this PR completes mkdocs-pr.yml successfully (the tutorial still executes; only prose is changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)