### PR TITLE
uses env variables to force notebook execution on GHA and adds abilit…

### DIFF
--- a/.github/workflows/mkdocs-ghp.yml
+++ b/.github/workflows/mkdocs-ghp.yml
@@ -27,7 +27,18 @@ jobs:
             mkdocs-material-
       - run: pip install ".[docs,examples]"
       - run: python scripts/convert_tutorials.py
-      - env:
+      - name: Build MkDocs site
+        env:
           MKDOCS_EXECUTE_NOTEBOOKS: true
           MKDOCS_ALLOW_ERRORS: false
-        run: mkdocs gh-deploy --force
+        run: mkdocs build
+      - name: Assert API reference content floor
+        run: |
+          ref_count=$(find site/reference -name 'index.html' 2>/dev/null | wc -l)
+          echo "rendered reference pages: $ref_count"
+          if [ "$ref_count" -lt 50 ]; then
+            echo "ERROR: site/reference is degraded (only $ref_count pages, expected 100+)"
+            exit 1
+          fi
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force --dirty

--- a/.github/workflows/mkdocs-ghp.yml
+++ b/.github/workflows/mkdocs-ghp.yml
@@ -27,4 +27,7 @@ jobs:
             mkdocs-material-
       - run: pip install ".[docs,examples]"
       - run: python scripts/convert_tutorials.py
-      - run: mkdocs gh-deploy --force --config-file mkdocs.ci.yml
+      - env:
+          MKDOCS_EXECUTE_NOTEBOOKS: true
+          MKDOCS_ALLOW_ERRORS: false
+        run: mkdocs gh-deploy --force

--- a/.github/workflows/mkdocs-pr.yml
+++ b/.github/workflows/mkdocs-pr.yml
@@ -24,4 +24,14 @@ jobs:
         run: python scripts/convert_tutorials.py
 
       - name: Build MkDocs site
-        run: mkdocs build --config-file mkdocs.ci.yml
+        env:
+          MKDOCS_EXECUTE_NOTEBOOKS: true
+          MKDOCS_ALLOW_ERRORS: false
+        run: mkdocs build
+
+      - name: Upload built site
+        uses: actions/upload-artifact@v4
+        with:
+          name: mkdocs-site-pr-${{ github.event.pull_request.number }}
+          path: site/
+          retention-days: 14

--- a/.github/workflows/mkdocs-pr.yml
+++ b/.github/workflows/mkdocs-pr.yml
@@ -29,6 +29,15 @@ jobs:
           MKDOCS_ALLOW_ERRORS: false
         run: mkdocs build
 
+      - name: Assert API reference content floor
+        run: |
+          ref_count=$(find site/reference -name 'index.html' 2>/dev/null | wc -l)
+          echo "rendered reference pages: $ref_count"
+          if [ "$ref_count" -lt 50 ]; then
+            echo "ERROR: site/reference is degraded (only $ref_count pages, expected 100+)"
+            exit 1
+          fi
+
       - name: Upload built site
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -50,10 +50,21 @@ jobs:
             mkdocs-material-
       - run: pip install ".[docs,examples]"
       - run: python scripts/convert_tutorials.py
-      - env:
+      - name: Build MkDocs site
+        env:
           MKDOCS_EXECUTE_NOTEBOOKS: true
           MKDOCS_ALLOW_ERRORS: false
-        run: mkdocs gh-deploy --force
+        run: mkdocs build
+      - name: Assert API reference content floor
+        run: |
+          ref_count=$(find site/reference -name 'index.html' 2>/dev/null | wc -l)
+          echo "rendered reference pages: $ref_count"
+          if [ "$ref_count" -lt 50 ]; then
+            echo "ERROR: site/reference is degraded (only $ref_count pages, expected 100+)"
+            exit 1
+          fi
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force --dirty
 
   github-release:
     name: >-

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -50,7 +50,10 @@ jobs:
             mkdocs-material-
       - run: pip install ".[docs,examples]"
       - run: python scripts/convert_tutorials.py
-      - run: mkdocs gh-deploy --force --config-file mkdocs.ci.yml
+      - env:
+          MKDOCS_EXECUTE_NOTEBOOKS: true
+          MKDOCS_ALLOW_ERRORS: false
+        run: mkdocs gh-deploy --force
 
   github-release:
     name: >-

--- a/mkdocs.ci.yml
+++ b/mkdocs.ci.yml
@@ -1,6 +1,0 @@
-INHERIT: mkdocs.yml
-
-plugins:
-  - mkdocs-jupyter:
-      execute: true
-      allow_errors: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,8 +116,10 @@ plugins:
   - include-markdown # include other files, such as READMEs
   - table-reader # enables rendering of CSV/TSV files as tables
   - mkdocs-jupyter: # enables Jupyter notebooks to be rendered
-      execute: false
-      allow_errors: true # set to true to continue executing cells even if one fails
+      # CI overrides via env vars (set in publish-pypi.yml, mkdocs-ghp.yml, mkdocs-pr.yml).
+      # Local dev runs without these and inherits the defaults below.
+      execute: !ENV [MKDOCS_EXECUTE_NOTEBOOKS, false]
+      allow_errors: !ENV [MKDOCS_ALLOW_ERRORS, true]
       include_source: true
       ignore: ["*.md"] # skip .md scanning to avoid jupytext→pandoc warnings on mkdocstrings autoref pages
   - gen-files:


### PR DESCRIPTION
…y to download build artifacts

Instead of using a separate overlay yaml file to set the notebooks to execute without errors on GHA builds, this sets an environment variable in the GHA file to do the same. This can be more easily tested locally. Additionally, uploads the build artifacts to GH as part of the PR build so it's easy to review the build before the PR is merged. Keep in mind that the build uses directory URLs so you will need to navigate the directory structure when viewing locally. 