### PR TITLE
Fix silent doc regression: single mkdocs.yml with env-toggled notebook execution

### DIFF
--- a/.github/workflows/mkdocs-ghp.yml
+++ b/.github/workflows/mkdocs-ghp.yml
@@ -14,6 +14,10 @@ jobs:
       # to the IDM Artifactory mirror so gh-pages deploys don't break when
       # geodata.ucdavis.edu is unreachable.
       LASER_GADM_MIRROR: https://packages.idmod.org/artifactory/idm-data
+      # Execute notebooks for the gh-pages build (the deployed docs site
+      # shows rendered notebook outputs).
+      MKDOCS_JUPYTER_EXECUTE: "true"
+      MKDOCS_JUPYTER_ALLOW_ERRORS: "false"
     steps:
       - uses: actions/checkout@v4
       - name: Configure Git Credentials
@@ -32,4 +36,16 @@ jobs:
             mkdocs-material-
       - run: pip install ".[docs,examples]"
       - run: python scripts/convert_tutorials.py
-      - run: mkdocs gh-deploy --force --config-file mkdocs.ci.yml
+      # Build separately from gh-deploy so we can assert the content floor
+      # before publishing. (gh-deploy doesn't expose a "build to local dir,
+      # validate, then push" mode; doing it in two steps gives us the gate.)
+      - run: mkdocs build
+      - name: Assert API reference content floor (gate before deploy)
+        run: |
+          ref_count=$(find site/reference -name 'index.html' 2>/dev/null | wc -l)
+          echo "rendered reference pages: $ref_count"
+          if [ "$ref_count" -lt 50 ]; then
+            echo "ERROR: site/reference is degraded (only $ref_count pages, expected 100+); NOT deploying."
+            exit 1
+          fi
+      - run: mkdocs gh-deploy --force

--- a/.github/workflows/mkdocs-pr.yml
+++ b/.github/workflows/mkdocs-pr.yml
@@ -12,6 +12,11 @@ jobs:
       # Artifactory mirror so PR builds don't break when geodata.ucdavis.edu
       # is unreachable.
       LASER_GADM_MIRROR: https://packages.idmod.org/artifactory/idm-data
+      # Execute notebooks during CI builds (vs the default false used locally).
+      # `allow_errors: false` fails the build on any cell error — desirable
+      # for CI; locally tutorials may be in flux and errors are acceptable.
+      MKDOCS_JUPYTER_EXECUTE: "true"
+      MKDOCS_JUPYTER_ALLOW_ERRORS: "false"
 
     steps:
       - name: Checkout code
@@ -29,4 +34,28 @@ jobs:
         run: python scripts/convert_tutorials.py
 
       - name: Build MkDocs site
-        run: mkdocs build --config-file mkdocs.ci.yml
+        run: mkdocs build
+
+      - name: Assert API reference content floor
+        # Content-floor guard against silent doc regressions. The 2026-06-03
+        # introduction of mkdocs.ci.yml dropped 7 of 8 plugins (including
+        # mkdocstrings), producing a site with zero API reference pages for
+        # nearly a month with exit code 0. This assertion would have failed
+        # that build's CI on its first run.
+        #
+        # Threshold of 50 is loose (the current main has 101 reference pages)
+        # so genuine reorganizations have headroom, but any catastrophic
+        # plugin or config regression that wipes out the API reference will
+        # fail loud here.
+        #
+        # Future improvement: `mkdocs build --strict` would catch the
+        # underlying warnings before they manifest as content loss, but
+        # currently fails on ~36 pre-existing warnings (mostly griffe
+        # type-annotation gaps). After those are cleaned up, add --strict.
+        run: |
+          ref_count=$(find site/reference -name 'index.html' 2>/dev/null | wc -l)
+          echo "rendered reference pages: $ref_count"
+          if [ "$ref_count" -lt 50 ]; then
+            echo "ERROR: site/reference is degraded (only $ref_count pages, expected 100+)"
+            exit 1
+          fi

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -37,6 +37,9 @@ jobs:
       # to the IDM Artifactory mirror so releases don't break when
       # geodata.ucdavis.edu is unreachable.
       LASER_GADM_MIRROR: https://packages.idmod.org/artifactory/idm-data
+      # Execute notebooks for the release-time docs deploy.
+      MKDOCS_JUPYTER_EXECUTE: "true"
+      MKDOCS_JUPYTER_ALLOW_ERRORS: "false"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Configure Git Credentials
@@ -55,7 +58,18 @@ jobs:
             mkdocs-material-
       - run: pip install ".[docs,examples]"
       - run: python scripts/convert_tutorials.py
-      - run: mkdocs gh-deploy --force --config-file mkdocs.ci.yml
+      # Build separately from gh-deploy so we can assert the content floor
+      # before publishing the release-time docs.
+      - run: mkdocs build
+      - name: Assert API reference content floor (gate before deploy)
+        run: |
+          ref_count=$(find site/reference -name 'index.html' 2>/dev/null | wc -l)
+          echo "rendered reference pages: $ref_count"
+          if [ "$ref_count" -lt 50 ]; then
+            echo "ERROR: site/reference is degraded (only $ref_count pages, expected 100+); NOT deploying."
+            exit 1
+          fi
+      - run: mkdocs gh-deploy --force
 
   github-release:
     name: >-

--- a/mkdocs.ci.yml
+++ b/mkdocs.ci.yml
@@ -1,6 +1,0 @@
-INHERIT: mkdocs.yml
-
-plugins:
-  - mkdocs-jupyter:
-      execute: true
-      allow_errors: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,8 +116,24 @@ plugins:
   - include-markdown # include other files, such as READMEs
   - table-reader # enables rendering of CSV/TSV files as tables
   - mkdocs-jupyter: # enables Jupyter notebooks to be rendered
-      execute: false
-      allow_errors: true # set to true to continue executing cells even if one fails
+      # `execute` and `allow_errors` are env-toggled so we can keep ONE
+      # authoritative mkdocs.yml with the full plugin list in both local
+      # and CI builds, and only change notebook execution between them.
+      #
+      # The previous pattern (a separate mkdocs.ci.yml inheriting from
+      # mkdocs.yml and overriding the entire `plugins:` list) was a silent
+      # content regression: MkDocs's INHERIT deep-merges dict-typed keys
+      # but REPLACES list-typed ones, so the CI build dropped mkdocstrings,
+      # gen-files, literate-nav, autorefs, include-markdown, table-reader,
+      # and exclude — producing a site with zero API reference pages and
+      # broken cross-links, with exit code 0.
+      #
+      # Local (fast):                 mkdocs build
+      # CI (notebooks executed):      MKDOCS_JUPYTER_EXECUTE=true \
+      #                               MKDOCS_JUPYTER_ALLOW_ERRORS=false \
+      #                               mkdocs build --strict
+      execute: !ENV [MKDOCS_JUPYTER_EXECUTE, false]
+      allow_errors: !ENV [MKDOCS_JUPYTER_ALLOW_ERRORS, true]
       include_source: true
       ignore: ["*.md"] # skip .md scanning to avoid jupytext→pandoc warnings on mkdocstrings autoref pages
   - gen-files:


### PR DESCRIPTION
## Summary — silent content regression

`mkdocs.ci.yml` (introduced 2026-06-03 in #254) inherited from `mkdocs.yml` via `INHERIT:` and overrode the `plugins:` list with just `mkdocs-jupyter`. MkDocs's `INHERIT` semantics deep-merge dict-typed keys but **replace list-typed ones outright**, so the CI build silently dropped 7 of 8 plugins (including `mkdocstrings`, `gen-files`, `autorefs`, `include-markdown`, `table-reader`, `literate-nav`, `exclude`) — producing a site missing **all 101 API reference pages**, with broken cross-links, but exit code 0.

Affected workflows:
- `mkdocs-pr.yml` — per-PR validation against a degraded site (gives false confidence)
- `mkdocs-ghp.yml` — gh-pages deploy → the live `laser.idmod.org/laser-measles/` site has likely been degraded since the introduction
- `publish-pypi.yml` (docs-deploy job) — release-time docs deploy

Unaffected:
- `build-jenner-doc.yml` — uses bare `mkdocs build` → reads `mkdocs.yml`. That's why the Jenner RAG artifact has had a healthy 101-page reference all along.

## Reproduction (local)

```
$ mkdocs build --config-file mkdocs.ci.yml --site-dir /tmp/site-ci
$ mkdocs build                              --site-dir /tmp/site-full
$ find /tmp/site-ci/reference   -name 'index.html' | wc -l    →   0
$ find /tmp/site-full/reference -name 'index.html' | wc -l    → 101
```

`mkdocs build --config-file mkdocs.ci.yml` also emits 17+ "not found in documentation files" warnings (every tutorial, the whole reference section).

## Fix

One authoritative `mkdocs.yml` with the full plugin list. Toggle notebook execution via env vars:

```yaml
  - mkdocs-jupyter:
      execute: !ENV [MKDOCS_JUPYTER_EXECUTE, false]
      allow_errors: !ENV [MKDOCS_JUPYTER_ALLOW_ERRORS, true]
```

```bash
# Local (fast, no notebook execution)
mkdocs build

# CI (notebook execution)
MKDOCS_JUPYTER_EXECUTE=true MKDOCS_JUPYTER_ALLOW_ERRORS=false mkdocs build
```

Deletes `mkdocs.ci.yml`. Updates the three affected workflows to drop the `--config-file` flag and set the env vars at job level.

## Preventing recurrence

Adds a content-floor assertion after `mkdocs build` in each affected workflow:

```bash
ref_count=$(find site/reference -name 'index.html' | wc -l)
if [ "$ref_count" -lt 50 ]; then exit 1; fi
```

Current main has 101 reference pages; the 50-page floor leaves ~50% headroom for genuine reorganizations but catches any future plugin/config regression that wipes out the API reference.

For `mkdocs-ghp.yml` and `publish-pypi.yml`, the previous one-step `mkdocs gh-deploy --force --config-file mkdocs.ci.yml` is now a two-step `mkdocs build` + content-floor assert + `mkdocs gh-deploy --force` so the assertion gates the deploy.

## Future improvement (not in this PR)

`mkdocs build --strict` would catch the underlying plugin warnings before they manifest as content loss. Currently fails on ~36 pre-existing warnings (mostly griffe `model`/`tick` annotation gaps + one autorefs miss to laser-core). After those are cleaned up, switch the workflows to `mkdocs build --strict`. Documented in the mkdocs.yml inline comment.

## Test plan

- [x] Local: `mkdocs build` → 101 reference pages, content floor PASS
- [x] Local CI-equivalent: `LASER_GADM_MIRROR=... MKDOCS_JUPYTER_EXECUTE=true MKDOCS_JUPYTER_ALLOW_ERRORS=false mkdocs build` → 101 reference pages, content floor PASS, ~5 min wall-clock for notebook execution
- [ ] CI on this PR (mkdocs-pr.yml) completes the build + content-floor assertion successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)